### PR TITLE
Fix type declarations

### DIFF
--- a/.changeset/good-melons-sniff.md
+++ b/.changeset/good-melons-sniff.md
@@ -1,0 +1,12 @@
+---
+"@drupal-kit/simple-oauth-auth-code": patch
+"@drupal-kit/config-typescript": patch
+"@drupal-kit/simple-oauth": patch
+"@drupal-kit/verification": patch
+"@drupal-kit/consumers": patch
+"@drupal-kit/user-api": patch
+"@drupal-kit/jsonapi": patch
+"@drupal-kit/core": patch
+---
+
+Fix `Result` type declarations and improve return type of functions that return a `Result` type.

--- a/packages/config/typescript/base.json
+++ b/packages/config/typescript/base.json
@@ -4,18 +4,16 @@
   "compilerOptions": {
     "target": "es2018",
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
+    "allowJs": false,
+    "skipLibCheck": false,
     "strict": true,
     "strictNullChecks": true,
-    "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node16",
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noUncheckedIndexedAccess": true
+    "isolatedModules": true
   },
   "exclude": ["node_modules"],
   "ts-node": {

--- a/packages/consumers/package.json
+++ b/packages/consumers/package.json
@@ -3,8 +3,7 @@
   "version": "0.3.1",
   "type": "module",
   "dependencies": {
-    "@drupal-kit/core": "workspace:0.3.1",
-    "@wunderwerk/ts-results": "^0.1.1"
+    "@drupal-kit/core": "workspace:0.3.1"
   },
   "devDependencies": {
     "@drupal-kit/config-typescript": "workspace:0.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@wunderwerk/ts-results": "^0.1.1",
+    "@wunderwerk/ts-functional": "1.0.0-beta.2",
     "before-after-hook": "^3.0.2",
     "is-plain-object": "^5.0.0",
     "node-fetch": "^3.3.1",

--- a/packages/core/src/Drupalkit.ts
+++ b/packages/core/src/Drupalkit.ts
@@ -1,4 +1,4 @@
-import { Result } from "@wunderwerk/ts-results";
+import { Result } from "@wunderwerk/ts-functional/results";
 import Hook, { HookCollection } from "before-after-hook";
 import qs from "qs";
 import {
@@ -134,7 +134,10 @@ export class Drupalkit {
    * @param url - Relative or absolute url.
    * @param options - Request options.
    */
-  public request<R>(url: Url, options: RequestOptions) {
+  public request<R>(
+    url: Url,
+    options: RequestOptions,
+  ): Promise<Result<DrupalkitResponse<R, number>, DrupalkitError>> {
     // eslint-disable-next-line jsdoc/require-jsdoc
     const request = (options: RequestRequestOptions) => {
       return fetchWrapper<R>(options);
@@ -162,7 +165,7 @@ export class Drupalkit {
       headers,
     };
 
-    return this.hook("request", request, requestOptions)
+    const p = this.hook("request", request, requestOptions)
       .then((response) => Result.Ok(response as DrupalkitResponse<R, number>))
       .catch((error) => {
         if (error instanceof DrupalkitError) return Result.Err(error);
@@ -173,6 +176,8 @@ export class Drupalkit {
           }),
         );
       });
+
+    return p;
   }
 
   /**

--- a/packages/jsonapi/package.json
+++ b/packages/jsonapi/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@drupal-kit/core": "workspace:0.3.1",
-    "@wunderwerk/ts-results": "^0.1.1",
+    "@wunderwerk/ts-functional": "1.0.0-beta.2",
     "drupal-jsonapi-params": "^2.2.0",
     "ts-json-api": "^1.2.0"
   },

--- a/packages/jsonapi/src/DrupalkitJsonApi.ts
+++ b/packages/jsonapi/src/DrupalkitJsonApi.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, Result } from "@wunderwerk/ts-results";
+import { Result } from "@wunderwerk/ts-functional/results";
 import { ResourceObject, Response } from "ts-json-api";
 import {
   Drupalkit,
@@ -47,7 +47,7 @@ export const DrupalkitJsonApi = (
    *
    * @returns A result object containing the JSON:API index or an error.
    */
-  const getIndex = async () => {
+  const getIndex = async (): Promise<Result<JsonApiIndex, DrupalkitError>> => {
     const url = buildJsonApiUrl("");
 
     const response = await drupalkit.request<JsonApiIndex>(url, {
@@ -79,7 +79,7 @@ export const DrupalkitJsonApi = (
     options?: {
       localeOverride?: string;
     },
-  ) => {
+  ): Promise<Result<Response<R>, DrupalkitError>> => {
     const path = type.replace("--", "/") + "/" + parameters.uuid;
 
     const url = buildJsonApiUrl(path, {
@@ -114,7 +114,7 @@ export const DrupalkitJsonApi = (
     options?: {
       localeOverride?: string;
     },
-  ) => {
+  ): Promise<Result<Response<R[]>, DrupalkitError>> => {
     const path = type.replace("--", "/");
 
     const url = buildJsonApiUrl(path, {
@@ -149,7 +149,7 @@ export const DrupalkitJsonApi = (
     options?: {
       localeOverride?: string;
     },
-  ) => {
+  ): Promise<Result<Response<R>, DrupalkitError>> => {
     const path = type.replace("--", "/");
 
     const url = buildJsonApiUrl(path, options);
@@ -182,7 +182,7 @@ export const DrupalkitJsonApi = (
     options?: {
       localeOverride?: string;
     },
-  ) => {
+  ): Promise<Result<Response<R>, DrupalkitError>> => {
     const path = type.replace("--", "/") + "/" + parameters.uuid;
 
     const url = buildJsonApiUrl(path, options);
@@ -210,7 +210,7 @@ export const DrupalkitJsonApi = (
   const deleteResource = async <R extends ResourceObject>(
     type: R["type"],
     parameters: DeleteParameters,
-  ) => {
+  ): Promise<Result<true, DrupalkitError>> => {
     const path = type.replace("--", "/") + "/" + parameters.uuid;
 
     const url = buildJsonApiUrl(path);
@@ -224,7 +224,7 @@ export const DrupalkitJsonApi = (
       return result;
     }
 
-    return Result.Ok(true);
+    return Result.Ok(true as const);
   };
 
   /**
@@ -278,16 +278,16 @@ export const DrupalkitJsonApi = (
         Return extends Record<
           Operation,
           "readSingle" extends Operation
-            ? Err<DrupalkitError> | Ok<Response<Resource>>
+            ? Result<Response<Resource>, DrupalkitError>
             : "readMany" extends Operation
-            ? Err<DrupalkitError> | Ok<Response<Resource[]>>
+            ? Result<Response<Resource[]>, DrupalkitError>
             : "create" extends Operation
             ? Awaited<ReturnType<typeof createResource>>
             : "update" extends Operation
             ? Awaited<ReturnType<typeof updateResource>>
             : "delete" extends Operation
             ? Awaited<ReturnType<typeof deleteResource>>
-            : Err<Error>
+            : Result<never, Error>
         >,
       >(
         type: Type,

--- a/packages/jsonapi/tsconfig.json
+++ b/packages/jsonapi/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@drupal-kit/config-typescript/base.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
   "include": ["src/**/*.ts"]
 }

--- a/packages/simple-oauth-auth-code/package.json
+++ b/packages/simple-oauth-auth-code/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@drupal-kit/core": "workspace:0.3.1",
-    "@wunderwerk/ts-results": "^0.1.1"
+    "@wunderwerk/ts-functional": "1.0.0-beta.2"
   },
   "devDependencies": {
     "@drupal-kit/config-typescript": "workspace:0.3.1",

--- a/packages/simple-oauth-auth-code/src/DrupalkitSimpleOauthAuthCode.ts
+++ b/packages/simple-oauth-auth-code/src/DrupalkitSimpleOauthAuthCode.ts
@@ -1,5 +1,5 @@
-import { Result } from "@wunderwerk/ts-results";
-import { Drupalkit, DrupalkitOptions } from "@drupal-kit/core";
+import { Result } from "@wunderwerk/ts-functional/results";
+import { Drupalkit, DrupalkitError, DrupalkitOptions } from "@drupal-kit/core";
 
 import { AuthCodeResponse } from "./types.js";
 
@@ -34,7 +34,10 @@ export const DrupalkitSimpleOauthAuthCode = <Operation extends string>(
    * @param operation - The operation this auth code is for.
    * @param email - The email address of the user.
    */
-  const requestAuthCode = async (operation: Operation, email: string) => {
+  const requestAuthCode = async (
+    operation: Operation,
+    email: string,
+  ): Promise<Result<AuthCodeResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(authCodeEndpoint);
 
     const result = await drupalkit.request<AuthCodeResponse>(url, {

--- a/packages/simple-oauth/package.json
+++ b/packages/simple-oauth/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@drupal-kit/core": "workspace:0.3.1",
-    "@wunderwerk/ts-results": "^0.1.1"
+    "@wunderwerk/ts-functional": "1.0.0-beta.2"
   },
   "devDependencies": {
     "@drupal-kit/config-typescript": "workspace:0.3.1",

--- a/packages/simple-oauth/src/DrupalkitSimpleOauth.ts
+++ b/packages/simple-oauth/src/DrupalkitSimpleOauth.ts
@@ -1,5 +1,5 @@
-import { Result } from "@wunderwerk/ts-results";
-import { Drupalkit, DrupalkitOptions } from "@drupal-kit/core";
+import { Result } from "@wunderwerk/ts-functional/results";
+import { Drupalkit, DrupalkitError, DrupalkitOptions } from "@drupal-kit/core";
 
 import { DrupalkitSimpleOauthError } from "./DrupalkitSimpleOauthError.js";
 import {
@@ -45,7 +45,7 @@ export const DrupalkitSimpleOauth = (
   >(
     grantType: GrantType,
     grant: Grant,
-  ) => {
+  ): Promise<Result<SimpleOauthTokenResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(oauthTokenEndpoint);
 
     const body = new URLSearchParams();
@@ -79,7 +79,9 @@ export const DrupalkitSimpleOauth = (
    * Do not forget to augment the SimpleOauthUserInfo interface
    * to match the OpenID Connect claims of your drupal installation!
    */
-  const getUserInfo = async () => {
+  const getUserInfo = async (): Promise<
+    Result<SimpleOauthUserInfo, DrupalkitError>
+  > => {
     const url = drupalkit.buildUrl(oauthUserInfoEndpoint);
 
     const result = await drupalkit.request<SimpleOauthUserInfo>(url, {

--- a/packages/user-api/package.json
+++ b/packages/user-api/package.json
@@ -5,7 +5,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@drupal-kit/core": "workspace:0.3.1",
-    "@wunderwerk/ts-results": "^0.1.1"
+    "@wunderwerk/ts-functional": "1.0.0-beta.2"
   },
   "devDependencies": {
     "@drupal-kit/config-typescript": "workspace:0.3.1",

--- a/packages/user-api/src/DrupalkitUserApi.ts
+++ b/packages/user-api/src/DrupalkitUserApi.ts
@@ -1,7 +1,7 @@
 import { Result } from "@wunderwerk/ts-results";
 import { Drupalkit, DrupalkitOptions } from "@drupal-kit/core";
 
-import { RegisterPayload, RegisterResponse } from "./types.js";
+import { RegisterPayload, RegisterResponse, SuccessResponse } from "./types.js";
 
 declare module "@drupal-kit/core" {
   interface DrupalkitOptions {
@@ -88,7 +88,7 @@ export const DrupalkitUserApi = (
   const initAccountCancel = async () => {
     const url = drupalkit.buildUrl(initAccountCancelEndpoint);
 
-    const result = await drupalkit.request<{ status: "success" }>(url, {
+    const result = await drupalkit.request<SuccessResponse>(url, {
       method: "POST",
       headers,
     });
@@ -112,7 +112,7 @@ export const DrupalkitUserApi = (
   const cancelAccount = async () => {
     const url = drupalkit.buildUrl(cancelAccountEndpoint);
 
-    const result = await drupalkit.request<{ status: "success" }>(url, {
+    const result = await drupalkit.request<SuccessResponse>(url, {
       method: "POST",
       headers,
     });
@@ -137,7 +137,7 @@ export const DrupalkitUserApi = (
   const resetPassword = async (email: string) => {
     const url = drupalkit.buildUrl(resetPasswordEndpoint);
 
-    const result = await drupalkit.request<{ status: "success" }>(url, {
+    const result = await drupalkit.request<SuccessResponse>(url, {
       method: "POST",
       body: { email },
       headers,
@@ -172,7 +172,7 @@ export const DrupalkitUserApi = (
       payload.currentPassword = currentPassword;
     }
 
-    const result = await drupalkit.request<{ status: "success" }>(url, {
+    const result = await drupalkit.request<SuccessResponse>(url, {
       method: "POST",
       body: payload,
       headers,
@@ -198,7 +198,7 @@ export const DrupalkitUserApi = (
   const passwordlessLogin = async (email: string) => {
     const url = drupalkit.buildUrl(passwordlessLoginEndpoint);
 
-    const result = await drupalkit.request<{ status: "success" }>(url, {
+    const result = await drupalkit.request<SuccessResponse>(url, {
       method: "POST",
       body: { email },
       unauthenticated: true,
@@ -225,7 +225,7 @@ export const DrupalkitUserApi = (
   const verifyEmail = async (email: string) => {
     const url = drupalkit.buildUrl(verifyEmailEndpoint);
 
-    const result = await drupalkit.request<{ status: "success" }>(url, {
+    const result = await drupalkit.request<SuccessResponse>(url, {
       method: "POST",
       body: { email },
       headers,
@@ -249,7 +249,7 @@ export const DrupalkitUserApi = (
   const updateEmail = async (email: string) => {
     const url = drupalkit.buildUrl(updateEmailEndpoint);
 
-    const result = await drupalkit.request<{ status: "success" }>(url, {
+    const result = await drupalkit.request<SuccessResponse>(url, {
       method: "POST",
       body: { email },
       headers,

--- a/packages/user-api/src/DrupalkitUserApi.ts
+++ b/packages/user-api/src/DrupalkitUserApi.ts
@@ -1,5 +1,5 @@
-import { Result } from "@wunderwerk/ts-results";
-import { Drupalkit, DrupalkitOptions } from "@drupal-kit/core";
+import { Result } from "@wunderwerk/ts-functional/results";
+import { Drupalkit, DrupalkitError, DrupalkitOptions } from "@drupal-kit/core";
 
 import { RegisterPayload, RegisterResponse, SuccessResponse } from "./types.js";
 
@@ -61,7 +61,9 @@ export const DrupalkitUserApi = (
    *
    * @param payload - The registration payload.
    */
-  const register = async (payload: RegisterPayload) => {
+  const register = async (
+    payload: RegisterPayload,
+  ): Promise<Result<RegisterResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(registrationEndpoint);
 
     const result = await drupalkit.request<RegisterResponse>(url, {
@@ -85,7 +87,9 @@ export const DrupalkitUserApi = (
    * This endpoint does not return useful data.
    * Only the status code is important.
    */
-  const initAccountCancel = async () => {
+  const initAccountCancel = async (): Promise<
+    Result<SuccessResponse, DrupalkitError>
+  > => {
     const url = drupalkit.buildUrl(initAccountCancelEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(url, {
@@ -109,7 +113,9 @@ export const DrupalkitUserApi = (
    * This endpoint does not return useful data.
    * Only the status code is important.
    */
-  const cancelAccount = async () => {
+  const cancelAccount = async (): Promise<
+    Result<SuccessResponse, DrupalkitError>
+  > => {
     const url = drupalkit.buildUrl(cancelAccountEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(url, {
@@ -134,7 +140,9 @@ export const DrupalkitUserApi = (
    *
    * @param email - E-Mail address of the user.
    */
-  const resetPassword = async (email: string) => {
+  const resetPassword = async (
+    email: string,
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(resetPasswordEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(url, {
@@ -162,7 +170,7 @@ export const DrupalkitUserApi = (
   const updatePassword = async (
     newPassword: string,
     currentPassword?: string,
-  ) => {
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(updatePasswordEndpoint);
 
     const payload: { newPassword: string; currentPassword?: string } = {
@@ -195,7 +203,9 @@ export const DrupalkitUserApi = (
    *
    * @param email - E-Mail address of the user.
    */
-  const passwordlessLogin = async (email: string) => {
+  const passwordlessLogin = async (
+    email: string,
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(passwordlessLoginEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(url, {
@@ -222,7 +232,9 @@ export const DrupalkitUserApi = (
    *
    * @param email - New E-Mail address of the user.
    */
-  const verifyEmail = async (email: string) => {
+  const verifyEmail = async (
+    email: string,
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(verifyEmailEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(url, {
@@ -246,7 +258,9 @@ export const DrupalkitUserApi = (
    *
    * @param email - New E-Mail address of the user.
    */
-  const updateEmail = async (email: string) => {
+  const updateEmail = async (
+    email: string,
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(updateEmailEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(url, {

--- a/packages/user-api/src/types.ts
+++ b/packages/user-api/src/types.ts
@@ -26,6 +26,13 @@ export interface RegisterResponse {
   content_translation_created?: [EntityFieldWithFormat];
 }
 
+/**
+ * Generic success response.
+ */
+export interface SuccessResponse {
+  status: "success";
+}
+
 export type EntityField<V = string> = {
   value: V;
 };

--- a/packages/verification/package.json
+++ b/packages/verification/package.json
@@ -4,8 +4,7 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@drupal-kit/core": "workspace:0.3.1",
-    "@wunderwerk/ts-results": "^0.1.1"
+    "@drupal-kit/core": "workspace:0.3.1"
   },
   "devDependencies": {
     "@drupal-kit/config-typescript": "workspace:0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,6 @@ importers:
       '@drupal-kit/types': workspace:0.3.1
       '@rollup/plugin-typescript': ^11.1.0
       '@swc/core': ^1.3.51
-      '@wunderwerk/ts-results': ^0.1.1
       ava: ^5.2.0
       esbuild: ^0.17.17
       msw: ^1.2.1
@@ -78,7 +77,6 @@ importers:
       typescript: 5.0.4
     dependencies:
       '@drupal-kit/core': link:../core
-      '@wunderwerk/ts-results': 0.1.1
     devDependencies:
       '@drupal-kit/config-typescript': link:../config/typescript
       '@drupal-kit/eslint-config': link:../config/eslint
@@ -103,7 +101,7 @@ importers:
       '@swc/core': ^1.3.51
       '@types/node-fetch': ^2.6.3
       '@types/qs': ^6.9.7
-      '@wunderwerk/ts-results': ^0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
       ava: ^5.2.0
       before-after-hook: ^3.0.2
       esbuild: ^0.17.17
@@ -117,7 +115,7 @@ importers:
       ts-node: ^10.9.1
       typescript: 5.0.4
     dependencies:
-      '@wunderwerk/ts-results': 0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
       before-after-hook: 3.0.2
       is-plain-object: 5.0.0_lray4voikhoiy5hx7wwtwhzd7e
       node-fetch: 3.3.1
@@ -147,7 +145,7 @@ importers:
       '@drupal-kit/types': workspace:0.3.1
       '@rollup/plugin-typescript': ^11.1.0
       '@swc/core': ^1.3.51
-      '@wunderwerk/ts-results': ^0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
       ava: ^5.2.0
       drupal-jsonapi-params: ^2.2.0
       esbuild: ^0.17.17
@@ -160,7 +158,7 @@ importers:
       typescript: 5.0.4
     dependencies:
       '@drupal-kit/core': link:../core
-      '@wunderwerk/ts-results': 0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
       drupal-jsonapi-params: 2.2.0
       ts-json-api: 1.2.0
     devDependencies:
@@ -186,7 +184,7 @@ importers:
       '@drupal-kit/types': workspace:0.3.1
       '@rollup/plugin-typescript': ^11.1.0
       '@swc/core': ^1.3.51
-      '@wunderwerk/ts-results': ^0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
       ava: ^5.2.0
       esbuild: ^0.17.17
       msw: ^1.2.1
@@ -197,7 +195,7 @@ importers:
       typescript: 5.0.4
     dependencies:
       '@drupal-kit/core': link:../core
-      '@wunderwerk/ts-results': 0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
     devDependencies:
       '@drupal-kit/config-typescript': link:../config/typescript
       '@drupal-kit/eslint-config': link:../config/eslint
@@ -221,7 +219,7 @@ importers:
       '@drupal-kit/types': workspace:0.3.1
       '@rollup/plugin-typescript': ^11.1.0
       '@swc/core': ^1.3.51
-      '@wunderwerk/ts-results': ^0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
       ava: ^5.2.0
       esbuild: ^0.17.17
       msw: ^1.2.1
@@ -232,7 +230,7 @@ importers:
       typescript: 5.0.4
     dependencies:
       '@drupal-kit/core': link:../core
-      '@wunderwerk/ts-results': 0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
     devDependencies:
       '@drupal-kit/config-typescript': link:../config/typescript
       '@drupal-kit/eslint-config': link:../config/eslint
@@ -266,7 +264,7 @@ importers:
       '@drupal-kit/types': workspace:0.3.1
       '@rollup/plugin-typescript': ^11.1.0
       '@swc/core': ^1.3.51
-      '@wunderwerk/ts-results': ^0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
       ava: ^5.2.0
       esbuild: ^0.17.17
       msw: ^1.2.1
@@ -277,7 +275,7 @@ importers:
       typescript: 5.0.4
     dependencies:
       '@drupal-kit/core': link:../core
-      '@wunderwerk/ts-results': 0.1.1
+      '@wunderwerk/ts-functional': 1.0.0-beta.2
     devDependencies:
       '@drupal-kit/config-typescript': link:../config/typescript
       '@drupal-kit/eslint-config': link:../config/eslint
@@ -301,7 +299,6 @@ importers:
       '@drupal-kit/types': workspace:0.3.1
       '@rollup/plugin-typescript': ^11.1.0
       '@swc/core': ^1.3.51
-      '@wunderwerk/ts-results': ^0.1.1
       ava: ^5.2.0
       esbuild: ^0.17.17
       msw: ^1.2.1
@@ -312,7 +309,6 @@ importers:
       typescript: 5.0.4
     dependencies:
       '@drupal-kit/core': link:../core
-      '@wunderwerk/ts-results': 0.1.1
     devDependencies:
       '@drupal-kit/config-typescript': link:../config/typescript
       '@drupal-kit/eslint-config': link:../config/eslint
@@ -1692,10 +1688,8 @@ packages:
       eslint-plugin-jsdoc: 41.1.2_eslint@8.38.0
     dev: true
 
-  /@wunderwerk/ts-results/0.1.1:
-    resolution: {integrity: sha512-wTJa63qZBgUJY7Pen8hlTyuiKBKnCB0EVF5jPmsuLhStCQHbRP4lFA5Nl6l0Lc/sSdcY8gFLowO3FzqLopW/6w==}
-    optionalDependencies:
-      rxjs: 7.8.0
+  /@wunderwerk/ts-functional/1.0.0-beta.2:
+    resolution: {integrity: sha512-8hfcmX1GI8DmCd/p/l13sa81KNf5cIkJnutib7TUIENaelpx5FvXJdma9cpF90b357+NPZ1zW8nm5OgsWZWyXA==}
     dev: false
 
   /@xmldom/xmldom/0.8.7:
@@ -2486,7 +2480,7 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       globby: 13.1.4
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       is-glob: 4.0.3
       is-path-cwd: 3.0.0
       is-path-inside: 4.0.0
@@ -2753,8 +2747,8 @@ packages:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
       debug: 3.2.7
-      is-core-module: 2.11.0
-      resolve: 1.22.1
+      is-core-module: 2.12.0
+      resolve: 1.22.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3486,7 +3480,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
@@ -3983,7 +3977,7 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
     dependencies:
-      chalk: 4.1.1
+      chalk: 4.1.2
       is-unicode-supported: 0.1.0
     dev: true
 
@@ -4352,7 +4346,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       bl: 4.1.0
-      chalk: 4.1.1
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.8.0
       is-interactive: 1.0.0
@@ -4727,7 +4721,7 @@ packages:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.11.0
+      is-core-module: 2.12.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -4817,6 +4811,7 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.5.0
+    dev: true
 
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -5285,6 +5280,7 @@ packages:
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: true
 
   /tsutils/3.21.0_typescript@5.0.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}


### PR DESCRIPTION
This PR fixes the ugly type declarations that are generated by the `ts-results` type.

TypeScript must not embed the `Result` type into the declaration, but import it from the external module instead.

In addition, the Result type should be set explicitly as the function return type. Otherwise TypeScript infers an intersection type: `ResultErr | ResultOk` which we do not want for a library.

## Tasks
- [x] Refactor all modules to use the result type from `@wunderwerk/ts-functional`
- [x] Add explicit function return type for all functions that return a `Result`. 

Fixes issue #6 