### PR TITLE
Return specific errors if applicable

### DIFF
--- a/.changeset/mean-donkeys-live.md
+++ b/.changeset/mean-donkeys-live.md
@@ -1,0 +1,6 @@
+---
+"@drupal-kit/simple-oauth": patch
+"@drupal-kit/jsonapi": patch
+---
+
+Return type of result is now the specific drupalkit error, if applicable

--- a/packages/jsonapi/src/DrupalkitJsonApi.ts
+++ b/packages/jsonapi/src/DrupalkitJsonApi.ts
@@ -47,21 +47,23 @@ export const DrupalkitJsonApi = (
    *
    * @returns A result object containing the JSON:API index or an error.
    */
-  const getIndex = async (): Promise<Result<JsonApiIndex, DrupalkitError>> => {
+  const getIndex = async (): Promise<
+    Result<JsonApiIndex, DrupalkitJsonApiError>
+  > => {
     const url = buildJsonApiUrl("");
 
-    const response = await drupalkit.request<JsonApiIndex>(url, {
+    const result = await drupalkit.request<JsonApiIndex>(url, {
       method: "GET",
       headers: {
         ...defaultHeaders,
       },
     });
 
-    if (response.err) {
-      return response;
+    if (result.err) {
+      return Result.Err(DrupalkitJsonApiError.fromDrupalkitError(result.val));
     }
 
-    return Result.Ok(response.val.data);
+    return Result.Ok(result.val.data);
   };
 
   /**
@@ -79,7 +81,7 @@ export const DrupalkitJsonApi = (
     options?: {
       localeOverride?: string;
     },
-  ): Promise<Result<Response<R>, DrupalkitError>> => {
+  ): Promise<Result<Response<R>, DrupalkitJsonApiError>> => {
     const path = type.replace("--", "/") + "/" + parameters.uuid;
 
     const url = buildJsonApiUrl(path, {
@@ -93,7 +95,7 @@ export const DrupalkitJsonApi = (
     });
 
     if (result.err) {
-      return result;
+      return Result.Err(DrupalkitJsonApiError.fromDrupalkitError(result.val));
     }
 
     return Result.Ok(result.val.data);
@@ -114,7 +116,7 @@ export const DrupalkitJsonApi = (
     options?: {
       localeOverride?: string;
     },
-  ): Promise<Result<Response<R[]>, DrupalkitError>> => {
+  ): Promise<Result<Response<R[]>, DrupalkitJsonApiError>> => {
     const path = type.replace("--", "/");
 
     const url = buildJsonApiUrl(path, {
@@ -128,7 +130,7 @@ export const DrupalkitJsonApi = (
     });
 
     if (result.err) {
-      return result;
+      return Result.Err(DrupalkitJsonApiError.fromDrupalkitError(result.val));
     }
 
     return Result.Ok(result.val.data);
@@ -149,7 +151,7 @@ export const DrupalkitJsonApi = (
     options?: {
       localeOverride?: string;
     },
-  ): Promise<Result<Response<R>, DrupalkitError>> => {
+  ): Promise<Result<Response<R>, DrupalkitJsonApiError>> => {
     const path = type.replace("--", "/");
 
     const url = buildJsonApiUrl(path, options);
@@ -161,7 +163,7 @@ export const DrupalkitJsonApi = (
     });
 
     if (result.err) {
-      return result;
+      return Result.Err(DrupalkitJsonApiError.fromDrupalkitError(result.val));
     }
 
     return Result.Ok(result.val.data);
@@ -182,7 +184,7 @@ export const DrupalkitJsonApi = (
     options?: {
       localeOverride?: string;
     },
-  ): Promise<Result<Response<R>, DrupalkitError>> => {
+  ): Promise<Result<Response<R>, DrupalkitJsonApiError>> => {
     const path = type.replace("--", "/") + "/" + parameters.uuid;
 
     const url = buildJsonApiUrl(path, options);
@@ -194,7 +196,7 @@ export const DrupalkitJsonApi = (
     });
 
     if (result.err) {
-      return result;
+      return Result.Err(DrupalkitJsonApiError.fromDrupalkitError(result.val));
     }
 
     return Result.Ok(result.val.data);
@@ -210,7 +212,7 @@ export const DrupalkitJsonApi = (
   const deleteResource = async <R extends ResourceObject>(
     type: R["type"],
     parameters: DeleteParameters,
-  ): Promise<Result<true, DrupalkitError>> => {
+  ): Promise<Result<true, DrupalkitJsonApiError>> => {
     const path = type.replace("--", "/") + "/" + parameters.uuid;
 
     const url = buildJsonApiUrl(path);
@@ -221,7 +223,7 @@ export const DrupalkitJsonApi = (
     });
 
     if (result.err) {
-      return result;
+      return Result.Err(DrupalkitJsonApiError.fromDrupalkitError(result.val));
     }
 
     return Result.Ok(true as const);

--- a/packages/simple-oauth/src/DrupalkitSimpleOauth.ts
+++ b/packages/simple-oauth/src/DrupalkitSimpleOauth.ts
@@ -45,7 +45,7 @@ export const DrupalkitSimpleOauth = (
   >(
     grantType: GrantType,
     grant: Grant,
-  ): Promise<Result<SimpleOauthTokenResponse, DrupalkitError>> => {
+  ): Promise<Result<SimpleOauthTokenResponse, DrupalkitSimpleOauthError>> => {
     const url = drupalkit.buildUrl(oauthTokenEndpoint);
 
     const body = new URLSearchParams();
@@ -64,7 +64,9 @@ export const DrupalkitSimpleOauth = (
     });
 
     if (result.err) {
-      return result;
+      return Result.Err(
+        DrupalkitSimpleOauthError.fromDrupalkitError(result.val),
+      );
     }
 
     return Result.Ok(result.val.data);

--- a/packages/simple-oauth/src/DrupalkitSimpleOauthError.ts
+++ b/packages/simple-oauth/src/DrupalkitSimpleOauthError.ts
@@ -88,19 +88,18 @@ export class DrupalkitSimpleOauthError extends DrupalkitError {
       ? this.extractErrorFromResponse(error.response.data)
       : null;
 
-    if (!errorData) {
-      return error;
-    }
+    const message = errorData?.message ?? error.message;
+    const oauthError = errorData?.error ?? null;
 
     return new this(
-      errorData.message ?? error.message,
+      message,
       error.statusCode,
-      errorData.error,
+      oauthError,
       {
         request: error.request,
         response: error.response,
       },
-      errorData.hint,
+      errorData?.hint,
     );
   }
 

--- a/packages/simple-oauth/src/types.ts
+++ b/packages/simple-oauth/src/types.ts
@@ -68,7 +68,8 @@ export type SimpleOauthError =
   | "invalid_scope"
   | "server_error"
   | "access_denied"
-  | "invalid_grant";
+  | "invalid_grant"
+  | null;
 
 export type SimpleOauthInvalidRequest =
   | "auth_code_expired"

--- a/packages/simple-oauth/tests/DrupalkitSimpleOauthError.test.ts
+++ b/packages/simple-oauth/tests/DrupalkitSimpleOauthError.test.ts
@@ -49,7 +49,7 @@ test("Instanciate from DrupalkitError", (t) => {
   t.assert(soError instanceof DrupalkitError);
 });
 
-test("Return DrupalkitError if error does not contain simple oauth error data", (t) => {
+test("OauthError should be null if error does not contain simple oauth error data", (t) => {
   // Without response.
   let error = new DrupalkitError("test-error", 400, {
     request,
@@ -57,8 +57,8 @@ test("Return DrupalkitError if error does not contain simple oauth error data", 
 
   let soError = DrupalkitSimpleOauthError.fromDrupalkitError(error);
 
-  t.assert(!(soError instanceof DrupalkitSimpleOauthError));
-  t.assert(soError instanceof DrupalkitError);
+  t.assert(soError instanceof DrupalkitSimpleOauthError);
+  t.is(soError.error, null);
 
   // Without payload.
   error = new DrupalkitError("test-error", 400, {
@@ -71,8 +71,8 @@ test("Return DrupalkitError if error does not contain simple oauth error data", 
 
   soError = DrupalkitSimpleOauthError.fromDrupalkitError(error);
 
-  t.assert(!(soError instanceof DrupalkitSimpleOauthError));
-  t.assert(soError instanceof DrupalkitError);
+  t.assert(soError instanceof DrupalkitSimpleOauthError);
+  t.is(soError.error, null);
 
   // With invalid payload.
   error = new DrupalkitError("test-error", 400, {
@@ -87,8 +87,8 @@ test("Return DrupalkitError if error does not contain simple oauth error data", 
 
   soError = DrupalkitSimpleOauthError.fromDrupalkitError(error);
 
-  t.assert(!(soError instanceof DrupalkitSimpleOauthError));
-  t.assert(soError instanceof DrupalkitError);
+  t.assert(soError instanceof DrupalkitSimpleOauthError);
+  t.is(soError.error, null);
 });
 
 test("Set error type, hint and message from response", (t) => {


### PR DESCRIPTION
The modules `jsonapi` and `simple-oauth` implement a specific kind of `DrupalkitError`.

Currently, the generic drupalkit errors are changed into the specific ones in a hook.
The error returned is actually the specific kind, however the return type indicates that the error is just a `DrupalkitError`.

Therefore, all methods that handle requests which are applicable for specific errors should return those explicitly.