### PR TITLE
feat: allow request option overrides for each request method

### DIFF
--- a/.changeset/hungry-boats-exist.md
+++ b/.changeset/hungry-boats-exist.md
@@ -1,0 +1,10 @@
+---
+"@drupal-kit/simple-oauth-auth-code": minor
+"@drupal-kit/simple-oauth": minor
+"@drupal-kit/user-api": minor
+"@drupal-kit/jsonapi": minor
+"@drupal-kit/types": minor
+"@drupal-kit/core": minor
+---
+
+Allow per-request request option overrides

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689680872,
-        "narHash": "sha256-brNix2+ihJSzCiKwLafbyejrHJZUP0Fy6z5+xMOC27M=",
+        "lastModified": 1690927903,
+        "narHash": "sha256-D5gCaCROnjEKDOel//8TO/pOP87pAEtT0uT8X+0Bj/U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "08700de174bc6235043cb4263b643b721d936bdb",
+        "rev": "bd836ac5e5a7358dea73cb74a013ca32864ccb86",
         "type": "github"
       },
       "original": {

--- a/packages/core/src/fetch-wrapper.ts
+++ b/packages/core/src/fetch-wrapper.ts
@@ -16,8 +16,6 @@ export default function fetchWrapper<R>(
     fetch?: Fetch;
   },
 ) {
-  //const log = requestOptions.log ? requestOptions.log : console;
-
   if (
     isPlainObject(requestOptions.body) ||
     Array.isArray(requestOptions.body)

--- a/packages/jsonapi/tests/menu.test.ts
+++ b/packages/jsonapi/tests/menu.test.ts
@@ -36,7 +36,7 @@ test.after(() => {
   server.close();
 });
 
-test("Get menu items", async (t) => {
+test.serial("Get menu items", async (t) => {
   const drupalkit = createDrupalkit();
 
   server.use(
@@ -55,7 +55,35 @@ test("Get menu items", async (t) => {
   t.snapshot(res);
 });
 
-test("Get menu items for non-existant menu", async (t) => {
+test.serial("Get menu items with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.get("*/jsonapi/menu_items/my_menu", (req, res, ctx) => {
+      t.is(req.headers.get("x-custom"), "1");
+
+      return res(
+        ctx.set("Content-Type", "application/vnd.api+json"),
+        ctx.json(JsonApiMenuItems),
+      );
+    }),
+  );
+
+  await drupalkit.jsonApi.getMenuItems("my_menu", {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
+});
+
+test.serial("Get menu items for non-existant menu", async (t) => {
   const drupalkit = createDrupalkit();
 
   server.use(

--- a/packages/simple-oauth-auth-code/src/DrupalkitSimpleOauthAuthCode.ts
+++ b/packages/simple-oauth-auth-code/src/DrupalkitSimpleOauthAuthCode.ts
@@ -1,5 +1,6 @@
 import { Result } from "@wunderwerk/ts-functional/results";
 import { Drupalkit, DrupalkitError, DrupalkitOptions } from "@drupal-kit/core";
+import { OverrideableRequestOptions } from "@drupal-kit/types";
 
 import { AuthCodeResponse } from "./types.js";
 
@@ -33,21 +34,27 @@ export const DrupalkitSimpleOauthAuthCode = <Operation extends string>(
    *
    * @param operation - The operation this auth code is for.
    * @param email - The email address of the user.
+   * @param requestOptions - Optional request options.
    */
   const requestAuthCode = async (
     operation: Operation,
     email: string,
+    requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<AuthCodeResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(authCodeEndpoint);
 
-    const result = await drupalkit.request<AuthCodeResponse>(url, {
-      method: "POST",
-      body: { operation, email },
-      unauthenticated: true,
-      headers: {
-        "content-type": "application/json",
+    const result = await drupalkit.request<AuthCodeResponse>(
+      url,
+      {
+        method: "POST",
+        body: { operation, email },
+        unauthenticated: true,
+        headers: {
+          "content-type": "application/json",
+        },
       },
-    });
+      requestOptions,
+    );
 
     if (result.err) {
       return result;

--- a/packages/simple-oauth-auth-code/tests/DrupalkitSimpleOauthAuthCode.test.ts
+++ b/packages/simple-oauth-auth-code/tests/DrupalkitSimpleOauthAuthCode.test.ts
@@ -54,6 +54,33 @@ test.serial("Request auth code", async (t) => {
   t.deepEqual(res, AuthCodeResponse);
 });
 
+test.serial("Request auth code with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  const operation = "register";
+  const email = "F3f6Z@example.com";
+
+  server.use(
+    rest.post("*/simple-oauth/auth-code", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+      return res(ctx.json(AuthCodeResponse));
+    }),
+  );
+
+  await drupalkit.simpleOauth.requestAuthCode(operation, email, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
+});
+
 test.serial("Request auth code with explicit endpoint", async (t) => {
   const endpoint = "/custom/auth-code";
   const drupalkit = createDrupalkit({

--- a/packages/simple-oauth/src/DrupalkitSimpleOauth.ts
+++ b/packages/simple-oauth/src/DrupalkitSimpleOauth.ts
@@ -1,5 +1,6 @@
 import { Result } from "@wunderwerk/ts-functional/results";
 import { Drupalkit, DrupalkitError, DrupalkitOptions } from "@drupal-kit/core";
+import { OverrideableRequestOptions } from "@drupal-kit/types";
 
 import { DrupalkitSimpleOauthError } from "./DrupalkitSimpleOauthError.js";
 import {
@@ -38,6 +39,7 @@ export const DrupalkitSimpleOauth = (
    *
    * @param grantType - The grant type to use.
    * @param grant - Grant options object.
+   * @param requestOptions - Optional request options.
    */
   const requestToken = async <
     GrantType extends keyof SimpleOauthGrantTypes,
@@ -45,6 +47,7 @@ export const DrupalkitSimpleOauth = (
   >(
     grantType: GrantType,
     grant: Grant,
+    requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SimpleOauthTokenResponse, DrupalkitSimpleOauthError>> => {
     const url = drupalkit.buildUrl(oauthTokenEndpoint);
 
@@ -54,14 +57,18 @@ export const DrupalkitSimpleOauth = (
       body.append(key, value);
     }
 
-    const result = await drupalkit.request<SimpleOauthTokenResponse>(url, {
-      method: "POST",
-      body,
-      unauthenticated: true,
-      headers: {
-        "content-type": "application/x-www-form-urlencoded",
+    const result = await drupalkit.request<SimpleOauthTokenResponse>(
+      url,
+      {
+        method: "POST",
+        body,
+        unauthenticated: true,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+        },
       },
-    });
+      requestOptions,
+    );
 
     if (result.err) {
       return Result.Err(
@@ -80,18 +87,24 @@ export const DrupalkitSimpleOauth = (
    *
    * Do not forget to augment the SimpleOauthUserInfo interface
    * to match the OpenID Connect claims of your drupal installation!
+   *
+   * @param requestOptions - Optional request options.
    */
-  const getUserInfo = async (): Promise<
-    Result<SimpleOauthUserInfo, DrupalkitError>
-  > => {
+  const getUserInfo = async (
+    requestOptions?: OverrideableRequestOptions,
+  ): Promise<Result<SimpleOauthUserInfo, DrupalkitError>> => {
     const url = drupalkit.buildUrl(oauthUserInfoEndpoint);
 
-    const result = await drupalkit.request<SimpleOauthUserInfo>(url, {
-      method: "GET",
-      headers: {
-        "content-type": "application/json",
+    const result = await drupalkit.request<SimpleOauthUserInfo>(
+      url,
+      {
+        method: "GET",
+        headers: {
+          "content-type": "application/json",
+        },
       },
-    });
+      requestOptions,
+    );
 
     if (result.err) {
       return result;

--- a/packages/simple-oauth/tests/DrupalkitSimpleOauth.test.ts
+++ b/packages/simple-oauth/tests/DrupalkitSimpleOauth.test.ts
@@ -82,6 +82,38 @@ test.serial("Request token with client credentials grant", async (t) => {
   t.snapshot(res);
 });
 
+test.serial("Request token with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/oauth/token", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(TokenResponse));
+    }),
+  );
+
+  await drupalkit.simpleOauth.requestToken(
+    "client_credentials",
+    {
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    },
+    {
+      cache: "no-cache",
+      headers: {
+        "X-Custom": "1",
+      },
+    },
+  );
+});
+
 test.serial("Request token with explicit endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
@@ -184,6 +216,31 @@ test.serial("Request user info", async (t) => {
   const res = result.unwrap();
 
   t.snapshot(res);
+});
+
+test.serial("Request user info with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.get("*/oauth/userinfo", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(UserInfoResponse));
+    }),
+  );
+
+  await drupalkit.simpleOauth.getUserInfo({
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
 });
 
 test.serial("Request user info with explicit endpoint", async (t) => {

--- a/packages/types/src/RequestOptions.ts
+++ b/packages/types/src/RequestOptions.ts
@@ -4,11 +4,29 @@ import { RequestHeaders } from "./RequestHeaders";
 /**
  * Drupalkit-specific request options.
  */
-export type RequestOptions = {
+export type RequestOptions = OverrideableRequestOptions & {
   /**
    * Request method.
    */
   method: string;
+
+  /**
+   * Request body.
+   */
+  body?: string | Array<unknown> | object;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [option: string]: any;
+};
+
+export type OverrideableRequestOptions = Omit<
+  RequestInit,
+  "headers" | "method" | "body"
+> & {
+  /**
+   * Override the locale for the request.
+   */
+  locale?: string;
 
   /**
    * Additional request headers.
@@ -16,22 +34,9 @@ export type RequestOptions = {
   headers?: RequestHeaders;
 
   /**
-   * Request body.
-   */
-  body?: string | Array<unknown> | object;
-
-  /**
-   * Override the locale for the request.
-   */
-  locale?: string;
-
-  /**
    * If true, the request will be unauthenticated.
    */
   unauthenticated?: boolean;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [option: string]: any;
 };
 
 /**

--- a/packages/user-api/src/DrupalkitUserApi.ts
+++ b/packages/user-api/src/DrupalkitUserApi.ts
@@ -1,5 +1,6 @@
 import { Result } from "@wunderwerk/ts-functional/results";
 import { Drupalkit, DrupalkitError, DrupalkitOptions } from "@drupal-kit/core";
+import { OverrideableRequestOptions } from "@drupal-kit/types";
 
 import { RegisterPayload, RegisterResponse, SuccessResponse } from "./types.js";
 
@@ -63,17 +64,23 @@ export const DrupalkitUserApi = (
    * interfaces to suit your needs!
    *
    * @param payload - The registration payload.
+   * @param requestOptions - Optional request options.
    */
   const register = async (
     payload: RegisterPayload,
+    requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<RegisterResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(registrationEndpoint);
 
-    const result = await drupalkit.request<RegisterResponse>(url, {
-      method: "POST",
-      body: payload,
-      headers,
-    });
+    const result = await drupalkit.request<RegisterResponse>(
+      url,
+      {
+        method: "POST",
+        body: payload,
+        headers,
+      },
+      requestOptions,
+    );
 
     if (result.err) {
       return result;
@@ -89,16 +96,22 @@ export const DrupalkitUserApi = (
    *
    * This endpoint does not return useful data.
    * Only the status code is important.
+   *
+   * @param requestOptions - Optional request options.
    */
-  const initAccountCancel = async (): Promise<
-    Result<SuccessResponse, DrupalkitError>
-  > => {
+  const initAccountCancel = async (
+    requestOptions?: OverrideableRequestOptions,
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(initAccountCancelEndpoint);
 
-    const result = await drupalkit.request<SuccessResponse>(url, {
-      method: "POST",
-      headers,
-    });
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        headers,
+      },
+      requestOptions,
+    );
 
     if (result.err) {
       return result;
@@ -115,16 +128,22 @@ export const DrupalkitUserApi = (
    *
    * This endpoint does not return useful data.
    * Only the status code is important.
+   *
+   * @param requestOptions - Optional request options.
    */
-  const cancelAccount = async (): Promise<
-    Result<SuccessResponse, DrupalkitError>
-  > => {
+  const cancelAccount = async (
+    requestOptions?: OverrideableRequestOptions,
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(cancelAccountEndpoint);
 
-    const result = await drupalkit.request<SuccessResponse>(url, {
-      method: "POST",
-      headers,
-    });
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        headers,
+      },
+      requestOptions,
+    );
 
     if (result.err) {
       return result;
@@ -142,17 +161,23 @@ export const DrupalkitUserApi = (
    * Only the status code is important.
    *
    * @param email - E-Mail address of the user.
+   * @param requestOptions - Optional request options.
    */
   const resetPassword = async (
     email: string,
+    requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(resetPasswordEndpoint);
 
-    const result = await drupalkit.request<SuccessResponse>(url, {
-      method: "POST",
-      body: { email },
-      headers,
-    });
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        body: { email },
+        headers,
+      },
+      requestOptions,
+    );
 
     if (result.err) {
       return result;
@@ -169,10 +194,12 @@ export const DrupalkitUserApi = (
    *
    * @param newPassword - The new password to set for the user.
    * @param currentPassword - The current password for the user.
+   * @param requestOptions - Optional request options.
    */
   const updatePassword = async (
     newPassword: string,
     currentPassword?: string,
+    requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(updatePasswordEndpoint);
 
@@ -183,11 +210,15 @@ export const DrupalkitUserApi = (
       payload.currentPassword = currentPassword;
     }
 
-    const result = await drupalkit.request<SuccessResponse>(url, {
-      method: "POST",
-      body: payload,
-      headers,
-    });
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        body: payload,
+        headers,
+      },
+      requestOptions,
+    );
 
     if (result.err) {
       return result;
@@ -205,18 +236,24 @@ export const DrupalkitUserApi = (
    * Only the status code is important.
    *
    * @param email - E-Mail address of the user.
+   * @param requestOptions - Optional request options.
    */
   const passwordlessLogin = async (
     email: string,
+    requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(passwordlessLoginEndpoint);
 
-    const result = await drupalkit.request<SuccessResponse>(url, {
-      method: "POST",
-      body: { email },
-      unauthenticated: true,
-      headers,
-    });
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        body: { email },
+        unauthenticated: true,
+        headers,
+      },
+      requestOptions,
+    );
 
     if (result.err) {
       return result;
@@ -234,17 +271,23 @@ export const DrupalkitUserApi = (
    * Only the status code is important.
    *
    * @param email - New E-Mail address of the user.
+   * @param requestOptions - Optional request options.
    */
   const verifyEmail = async (
     email: string,
+    requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(verifyEmailEndpoint);
 
-    const result = await drupalkit.request<SuccessResponse>(url, {
-      method: "POST",
-      body: { email },
-      headers,
-    });
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        body: { email },
+        headers,
+      },
+      requestOptions,
+    );
 
     if (result.err) {
       return result;
@@ -260,17 +303,23 @@ export const DrupalkitUserApi = (
    * This endpoint requires verification via the verification plugin!
    *
    * @param email - New E-Mail address of the user.
+   * @param requestOptions - Optional request options.
    */
   const updateEmail = async (
     email: string,
+    requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(updateEmailEndpoint);
 
-    const result = await drupalkit.request<SuccessResponse>(url, {
-      method: "POST",
-      body: { email },
-      headers,
-    });
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        body: { email },
+        headers,
+      },
+      requestOptions,
+    );
 
     if (result.err) {
       return result;
@@ -286,17 +335,26 @@ export const DrupalkitUserApi = (
    *
    * @param email - E-Mail address to resend to.
    * @param operation - Operation of which to resend email.
+   * @param requestOptions - Optional request options.
    */
-  const resendVerificationEmail = async (email: string, operation: string) => {
+  const resendVerificationEmail = async (
+    email: string,
+    operation: string,
+    requestOptions?: OverrideableRequestOptions,
+  ) => {
     const url = drupalkit.buildUrl(resendMailEndpoint);
 
-    const result = await drupalkit.request<{ status: "success" }>(url, {
-      method: "POST",
-      body: { email, operation },
-      headers: {
-        "content-type": "application/json",
+    const result = await drupalkit.request<{ status: "success" }>(
+      url,
+      {
+        method: "POST",
+        body: { email, operation },
+        headers: {
+          "content-type": "application/json",
+        },
       },
-    });
+      requestOptions,
+    );
 
     if (result.err) {
       return result;

--- a/packages/user-api/tests/DrupalkitUserApi.test.ts
+++ b/packages/user-api/tests/DrupalkitUserApi.test.ts
@@ -69,6 +69,36 @@ test.serial("Register", async (t) => {
   t.deepEqual(res, UserResponse);
 });
 
+test.serial("Register with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  const payload = {
+    name: { value: "john-doe-1" },
+    mail: { value: "JzWZg@example.com" },
+  };
+
+  server.use(
+    rest.post("*/user-api/register", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(UserResponse));
+    }),
+  );
+
+  await drupalkit.userApi.register(payload, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
+});
+
 test.serial("Register with explicit endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
@@ -110,6 +140,10 @@ test.serial("Handle register error", async (t) => {
   t.assert(result.err);
 });
 
+/**
+ * initAccountCancel().
+ */
+
 test.serial("Init account cancel", async (t) => {
   t.plan(2);
 
@@ -128,6 +162,31 @@ test.serial("Init account cancel", async (t) => {
   const res = result.unwrap();
 
   t.deepEqual(res, successResponse);
+});
+
+test.serial("Init account cancel with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/init-account-cancel", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.initAccountCancel({
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
 });
 
 test.serial("Init account cancel with custom endpoint", async (t) => {
@@ -161,6 +220,10 @@ test.serial("Handle error while init account cancel", async (t) => {
   t.assert(result.err);
 });
 
+/**
+ * cancelAccount().
+ */
+
 test.serial("Cancel account", async (t) => {
   t.plan(2);
 
@@ -179,6 +242,31 @@ test.serial("Cancel account", async (t) => {
   const res = result.unwrap();
 
   t.deepEqual(res, successResponse);
+});
+
+test.serial("Cancel account with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/cancel-account", async (req, res, ctx) => {
+      t.is(req.headers.get("content-type"), "application/json");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.cancelAccount({
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
 });
 
 test.serial("Cancel account with custom endpoint", async (t) => {
@@ -237,6 +325,32 @@ test.serial("Reset password", async (t) => {
   const res = result.unwrap();
 
   t.deepEqual(res, successResponse);
+});
+
+test.serial("Reset password with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/reset-password", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.resetPassword(email, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
 });
 
 test.serial("Reset password with custom endpoint", async (t) => {
@@ -299,6 +413,32 @@ test.serial("Update password", async (t) => {
   t.deepEqual(res, successResponse);
 });
 
+test.serial("Update password with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+  const newPassword = "new-password";
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/update-password", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.updatePassword(newPassword, undefined, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
+});
+
 test.serial("Update password with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
@@ -357,6 +497,32 @@ test.serial("Passwordless login", async (t) => {
   const res = result.unwrap();
 
   t.deepEqual(res, successResponse);
+});
+
+test.serial("Passwordless login with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/passwordless-login", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.passwordlessLogin(email, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
 });
 
 test.serial("Passwordless login with custom endpoint", async (t) => {
@@ -419,6 +585,32 @@ test.serial("Verify email", async (t) => {
   t.deepEqual(res, successResponse);
 });
 
+test.serial("Verify email with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/verify-email", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.verifyEmail(email, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
+});
+
 test.serial("Verify email with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
@@ -477,6 +669,32 @@ test.serial("Update email", async (t) => {
   const res = result.unwrap();
 
   t.deepEqual(res, successResponse);
+});
+
+test.serial("Update email with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/update-email", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.updateEmail(email, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
 });
 
 test.serial("Update email with custom endpoint", async (t) => {
@@ -542,6 +760,36 @@ test.serial("Resend verification email", async (t) => {
 
   t.deepEqual(res, successResponse);
 });
+
+test.serial(
+  "Resend verification email with custom request options",
+  async (t) => {
+    t.plan(2);
+
+    const drupalkit = createDrupalkit();
+    const email = "JzWZg@example.com";
+    const operation = "register";
+
+    drupalkit.hook.before("request", (options) => {
+      t.is(options.cache, "no-cache");
+    });
+
+    server.use(
+      rest.post("*/user-api/resend-mail", async (req, res, ctx) => {
+        t.is(req.headers.get("X-Custom"), "1");
+
+        return res(ctx.json(successResponse));
+      }),
+    );
+
+    await drupalkit.userApi.resendVerificationEmail(email, operation, {
+      cache: "no-cache",
+      headers: {
+        "X-Custom": "1",
+      },
+    });
+  },
+);
 
 test.serial("Resend verification email with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({


### PR DESCRIPTION
This allows to override request options for each method. The override accepts almost all request options for the `fetch` function.

That also implicitly enables setting NextJS cache options and fixes #32  