### PR TITLE
Update user-api endpoints

### DIFF
--- a/.changeset/soft-drinks-yell.md
+++ b/.changeset/soft-drinks-yell.md
@@ -1,0 +1,5 @@
+---
+"@drupal-kit/user-api": minor
+---
+
+Update user-api methods to reflect latest changes in the drupal user_api module

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,21 +11,15 @@ jobs:
   lint-and-test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: nix develop --command bash {0}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: 8
-          run_install: false
+      - name: Install nix
+        uses: nixbuild/nix-quick-install-action@v25
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -41,9 +35,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Install dependencies
+      - name: Set token config
         run: |
-          pnpm install
+          echo "//npm.wunderwerk.dev/:_authToken=${NPM_TOKEN}" >> .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,21 +11,15 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: nix develop --command bash {0}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        id: pnpm-install
-        with:
-          version: 8
-          run_install: false
+      - name: Install nix
+        uses: nixbuild/nix-quick-install-action@v25
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -41,10 +35,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Install dependencies
+      - name: Set token config
         run: |
-          echo '//npm.wunderwerk.dev/:_authToken=${NPM_TOKEN}' > ~/.npmrc
-          pnpm install
+          echo "//npm.wunderwerk.dev/:_authToken=${NPM_TOKEN}" >> .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/packages/user-api/package.json
+++ b/packages/user-api/package.json
@@ -5,7 +5,8 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@drupal-kit/core": "workspace:0.9.2",
-    "@wunderwerk/ts-functional": "1.0.0-beta.2"
+    "@wunderwerk/ts-functional": "1.0.0-beta.2",
+    "util-deprecate": "^1.0.2"
   },
   "devDependencies": {
     "@drupal-kit/config-typescript": "workspace:0.9.2",
@@ -13,6 +14,7 @@
     "@drupal-kit/types": "workspace:0.9.2",
     "@rollup/plugin-typescript": "^11.1.1",
     "@swc/core": "^1.3.58",
+    "@types/util-deprecate": "^1.0.3",
     "ava": "^5.2.0",
     "esbuild": "^0.17.19",
     "msw": "^1.2.1",

--- a/packages/user-api/src/DrupalkitUserApi.ts
+++ b/packages/user-api/src/DrupalkitUserApi.ts
@@ -17,6 +17,7 @@ export const DrupalkitUserApi = (
   drupalkit: Drupalkit,
   drupalkitOptions: DrupalkitOptions,
 ) => {
+  // Support deprecated enpoint options.
   if (drupalkitOptions.userApiResendMailEndpoint) {
     drupalkitOptions.userApiRegisterResendEmailEndpoint =
       drupalkitOptions.userApiResendMailEndpoint;
@@ -42,6 +43,7 @@ export const DrupalkitUserApi = (
       drupalkitOptions.userApiUpdateEmailEndpoint;
   }
 
+  // Set endpoints.
   const registrationEndpoint =
     drupalkitOptions.userApiRegistrationEndpoint ?? "/user-api/register";
   const registerResendEmailEndpoint =

--- a/packages/user-api/src/DrupalkitUserApi.ts
+++ b/packages/user-api/src/DrupalkitUserApi.ts
@@ -32,25 +32,26 @@ export const DrupalkitUserApi = (
 ) => {
   const registrationEndpoint =
     drupalkitOptions.userApiRegistrationEndpoint ?? "/user-api/register";
-  const cancelAccountEndpoint =
-    drupalkitOptions.userApiCancelAccountEndpoint ?? "/user-api/cancel-account";
   const initAccountCancelEndpoint =
     drupalkitOptions.userApiInitAccountCancelEndpoint ??
-    "/user-api/init-account-cancel";
+    "/user-api/cancel-account/init";
+  const cancelAccountEndpoint =
+    drupalkitOptions.userApiCancelAccountEndpoint ?? "/user-api/cancel-account";
   const resetPasswordEndpoint =
-    drupalkitOptions.userApiResetPasswordEndpoint ?? "/user-api/reset-password";
+    drupalkitOptions.userApiResetPasswordEndpoint ??
+    "/user-api/set-password/init";
   const updatePasswordEndpoint =
-    drupalkitOptions.userApiUpdatePasswordEndpoint ??
-    "/user-api/update-password";
+    drupalkitOptions.userApiUpdatePasswordEndpoint ?? "/user-api/set-password";
   const passwordlessLoginEndpoint =
     drupalkitOptions.userApiPasswordlessLoginEndpoint ??
     "/user-api/passwordless-login";
   const updateEmailEndpoint =
-    drupalkitOptions.userApiUpdateEmailEndpoint ?? "/user-api/update-email";
+    drupalkitOptions.userApiUpdateEmailEndpoint ?? "/user-api/set-email";
   const verifyEmailEndpoint =
-    drupalkitOptions.userApiVerifyEmailEndpoint ?? "/user-api/verify-email";
+    drupalkitOptions.userApiVerifyEmailEndpoint ?? "/user-api/set-email/init";
   const resendMailEndpoint =
-    drupalkitOptions.userApiResendMailEndpoint ?? "/user-api/resend-mail";
+    drupalkitOptions.userApiResendMailEndpoint ??
+    "/user-api/register/resend-email";
 
   const headers = {
     "content-type": "application/json",

--- a/packages/user-api/src/DrupalkitUserApi.ts
+++ b/packages/user-api/src/DrupalkitUserApi.ts
@@ -3,6 +3,7 @@ import { Drupalkit, DrupalkitError, DrupalkitOptions } from "@drupal-kit/core";
 import { OverrideableRequestOptions } from "@drupal-kit/types";
 
 import { RegisterPayload, RegisterResponse, SuccessResponse } from "./types.js";
+import { deprecate } from "./utils.js";
 
 /**
  * DrupalkitUserApi plugin for Drupalkit.
@@ -17,22 +18,28 @@ export const DrupalkitUserApi = (
   drupalkitOptions: DrupalkitOptions,
 ) => {
   if (drupalkitOptions.userApiResendMailEndpoint) {
-    drupalkitOptions.userApiRegisterResendEmailEndpoint = drupalkitOptions.userApiResendMailEndpoint;
+    drupalkitOptions.userApiRegisterResendEmailEndpoint =
+      drupalkitOptions.userApiResendMailEndpoint;
   }
   if (drupalkitOptions.userApiInitAccountCancelEndpoint) {
-    drupalkitOptions.userApiInitCancelAccountEndpoint = drupalkitOptions.userApiInitAccountCancelEndpoint;
+    drupalkitOptions.userApiInitCancelAccountEndpoint =
+      drupalkitOptions.userApiInitAccountCancelEndpoint;
   }
   if (drupalkitOptions.userApiResetPasswordEndpoint) {
-    drupalkitOptions.userApiInitSetPasswordEndpoint = drupalkitOptions.userApiResetPasswordEndpoint;
+    drupalkitOptions.userApiInitSetPasswordEndpoint =
+      drupalkitOptions.userApiResetPasswordEndpoint;
   }
   if (drupalkitOptions.userApiUpdatePasswordEndpoint) {
-    drupalkitOptions.userApiSetPasswordEndpoint = drupalkitOptions.userApiUpdatePasswordEndpoint;
+    drupalkitOptions.userApiSetPasswordEndpoint =
+      drupalkitOptions.userApiUpdatePasswordEndpoint;
   }
   if (drupalkitOptions.userApiVerifyEmailEndpoint) {
-    drupalkitOptions.userApiInitSetEmailEndpoint = drupalkitOptions.userApiVerifyEmailEndpoint;
+    drupalkitOptions.userApiInitSetEmailEndpoint =
+      drupalkitOptions.userApiVerifyEmailEndpoint;
   }
   if (drupalkitOptions.userApiUpdateEmailEndpoint) {
-    drupalkitOptions.userApiSetEmailEndpoint = drupalkitOptions.userApiUpdateEmailEndpoint;
+    drupalkitOptions.userApiSetEmailEndpoint =
+      drupalkitOptions.userApiUpdateEmailEndpoint;
   }
 
   const registrationEndpoint =
@@ -100,6 +107,41 @@ export const DrupalkitUserApi = (
   };
 
   /**
+   * Resend verification email.
+   *
+   * Resend the verification email for the given operation.
+   *
+   * @param email - E-Mail address to resend to.
+   * @param operation - Operation of which to resend email.
+   * @param requestOptions - Optional request options.
+   */
+  const resendRegisterEmail = async (
+    email: string,
+    operation: string,
+    requestOptions?: OverrideableRequestOptions,
+  ) => {
+    const url = drupalkit.buildUrl(registerResendEmailEndpoint);
+
+    const result = await drupalkit.request<{ status: "success" }>(
+      url,
+      {
+        method: "POST",
+        body: { email, operation },
+        headers: {
+          "content-type": "application/json",
+        },
+      },
+      requestOptions,
+    );
+
+    if (result.err) {
+      return result;
+    }
+
+    return Result.Ok(result.val.data);
+  };
+
+  /**
    * Initialize account cancellation.
    *
    * The request MUST be authorized!
@@ -109,7 +151,7 @@ export const DrupalkitUserApi = (
    *
    * @param requestOptions - Optional request options.
    */
-  const initAccountCancel = async (
+  const initCancelAccount = async (
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
     const url = drupalkit.buildUrl(initCancelAccountEndpoint);
@@ -163,7 +205,7 @@ export const DrupalkitUserApi = (
   };
 
   /**
-   * Initialize password reset.
+   * Initialize set password.
    *
    * The request MUST be authorized!
    *
@@ -173,7 +215,7 @@ export const DrupalkitUserApi = (
    * @param email - E-Mail address of the user.
    * @param requestOptions - Optional request options.
    */
-  const resetPassword = async (
+  const initSetPassword = async (
     email: string,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
@@ -206,7 +248,7 @@ export const DrupalkitUserApi = (
    * @param currentPassword - The current password for the user.
    * @param requestOptions - Optional request options.
    */
-  const updatePassword = async (
+  const setPassword = async (
     newPassword: string,
     currentPassword?: string,
     requestOptions?: OverrideableRequestOptions,
@@ -273,7 +315,7 @@ export const DrupalkitUserApi = (
   };
 
   /**
-   * Verify new email change.
+   * Initialize email update.
    *
    * The request MUST be authorized!
    *
@@ -283,7 +325,7 @@ export const DrupalkitUserApi = (
    * @param email - New E-Mail address of the user.
    * @param requestOptions - Optional request options.
    */
-  const verifyEmail = async (
+  const initSetEmail = async (
     email: string,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
@@ -315,7 +357,7 @@ export const DrupalkitUserApi = (
    * @param email - New E-Mail address of the user.
    * @param requestOptions - Optional request options.
    */
-  const updateEmail = async (
+  const setEmail = async (
     email: string,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
@@ -339,54 +381,48 @@ export const DrupalkitUserApi = (
   };
 
   /**
-   * Resend verification email.
-   *
-   * Resend the verification email for the given operation.
-   *
-   * @param email - E-Mail address to resend to.
-   * @param operation - Operation of which to resend email.
-   * @param requestOptions - Optional request options.
-   */
-  const resendVerificationEmail = async (
-    email: string,
-    operation: string,
-    requestOptions?: OverrideableRequestOptions,
-  ) => {
-    const url = drupalkit.buildUrl(registerResendEmailEndpoint);
-
-    const result = await drupalkit.request<{ status: "success" }>(
-      url,
-      {
-        method: "POST",
-        body: { email, operation },
-        headers: {
-          "content-type": "application/json",
-        },
-      },
-      requestOptions,
-    );
-
-    if (result.err) {
-      return result;
-    }
-
-    return Result.Ok(result.val.data);
-  };
-
-  /**
    * Extend the Drupalkit instance.
    */
   return {
     userApi: {
       register,
-      initAccountCancel,
+      resendRegisterEmail,
+      initCancelAccount,
       cancelAccount,
-      resetPassword,
-      updatePassword,
+      initSetPassword,
+      setPassword,
       passwordlessLogin,
-      verifyEmail,
-      updateEmail,
-      resendVerificationEmail,
+      initSetEmail,
+      setEmail,
+      /* eslint-disable */
+      /**
+       * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `resendRegisterEmail` instead.
+       */
+      resendVerificationEmail: deprecate(
+        resendRegisterEmail,
+        "resendVerificationEmail",
+      ),
+      /**
+       * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `initCancelAccount` instead.
+       */
+      initAccountCancel: deprecate(initCancelAccount, "initAccountCancel"),
+      /**
+       * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `initSetPassword` instead.
+       */
+      resetPassword: deprecate(initSetPassword, "resetPassword"),
+      /**
+       * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `setPassword` instead.
+       */
+      updatePassword: deprecate(setPassword, "updatePassword"),
+      /**
+       * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `initSetEmail` instead.
+       */
+      verifyEmail: deprecate(initSetEmail, "verifyEmail"),
+      /**
+       * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `setEmail` instead.
+       */
+      updateEmail: deprecate(setEmail, "updateEmail"),
+      /* eslint-enable */
     },
   };
 };

--- a/packages/user-api/src/DrupalkitUserApi.ts
+++ b/packages/user-api/src/DrupalkitUserApi.ts
@@ -62,6 +62,12 @@ export const DrupalkitUserApi = (
   const setPasswordEndpoint =
     drupalkitOptions.userApiSetPasswordEndpoint ?? "/user-api/set-password";
 
+  const initUnetPasswordEndpoint =
+    drupalkitOptions.userApiInitUnsetPasswordEndpoint ??
+    "/user-api/unset-password/init";
+  const unsetPasswordEndpoint =
+    drupalkitOptions.userApiUnsetPasswordEndpoint ?? "/user-api/unset-password";
+
   const passwordlessLoginEndpoint =
     drupalkitOptions.userApiPasswordlessLoginEndpoint ??
     "/user-api/passwordless-login";
@@ -282,6 +288,77 @@ export const DrupalkitUserApi = (
   };
 
   /**
+   * Initialize unset password.
+   *
+   * The request MUST be authorized!
+   *
+   * This endpoint does not return useful data.
+   * Only the status code is important.
+   *
+   * @param email - E-Mail address of the user.
+   * @param requestOptions - Optional request options.
+   */
+  const initUnsetPassword = async (
+    email: string,
+    requestOptions?: OverrideableRequestOptions,
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
+    const url = drupalkit.buildUrl(initUnetPasswordEndpoint);
+
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        body: { email },
+        headers,
+      },
+      requestOptions,
+    );
+
+    if (result.err) {
+      return result;
+    }
+
+    return Result.Ok(result.val.data);
+  };
+
+  /**
+   * Unset user password.
+   *
+   * This endpoint must either supply the current password or
+   * be verified via the verification plugin!
+   *
+   * @param currentPassword - The current password for the user.
+   * @param requestOptions - Optional request options.
+   */
+  const unsetPassword = async (
+    currentPassword?: string,
+    requestOptions?: OverrideableRequestOptions,
+  ): Promise<Result<SuccessResponse, DrupalkitError>> => {
+    const url = drupalkit.buildUrl(unsetPasswordEndpoint);
+
+    const payload: { currentPassword?: string } = {};
+    if (currentPassword) {
+      payload.currentPassword = currentPassword;
+    }
+
+    const result = await drupalkit.request<SuccessResponse>(
+      url,
+      {
+        method: "POST",
+        body: payload,
+        headers,
+      },
+      requestOptions,
+    );
+
+    if (result.err) {
+      return result;
+    }
+
+    return Result.Ok(result.val.data);
+  };
+
+  /**
    * Trigger passwordless login.
    *
    * The request MUST be authorized!
@@ -393,6 +470,8 @@ export const DrupalkitUserApi = (
       cancelAccount,
       initSetPassword,
       setPassword,
+      initUnsetPassword,
+      unsetPassword,
       passwordlessLogin,
       initSetEmail,
       setEmail,

--- a/packages/user-api/src/DrupalkitUserApi.ts
+++ b/packages/user-api/src/DrupalkitUserApi.ts
@@ -4,20 +4,6 @@ import { OverrideableRequestOptions } from "@drupal-kit/types";
 
 import { RegisterPayload, RegisterResponse, SuccessResponse } from "./types.js";
 
-declare module "@drupal-kit/core" {
-  interface DrupalkitOptions {
-    userApiRegistrationEndpoint?: string;
-    userApiCancelAccountEndpoint?: string;
-    userApiInitAccountCancelEndpoint?: string;
-    userApiResetPasswordEndpoint?: string;
-    userApiUpdatePasswordEndpoint?: string;
-    userApiPasswordlessLoginEndpoint?: string;
-    userApiUpdateEmailEndpoint?: string;
-    userApiVerifyEmailEndpoint?: string;
-    userApiResendMailEndpoint?: string;
-  }
-}
-
 /**
  * DrupalkitUserApi plugin for Drupalkit.
  *
@@ -30,28 +16,51 @@ export const DrupalkitUserApi = (
   drupalkit: Drupalkit,
   drupalkitOptions: DrupalkitOptions,
 ) => {
+  if (drupalkitOptions.userApiResendMailEndpoint) {
+    drupalkitOptions.userApiRegisterResendEmailEndpoint = drupalkitOptions.userApiResendMailEndpoint;
+  }
+  if (drupalkitOptions.userApiInitAccountCancelEndpoint) {
+    drupalkitOptions.userApiInitCancelAccountEndpoint = drupalkitOptions.userApiInitAccountCancelEndpoint;
+  }
+  if (drupalkitOptions.userApiResetPasswordEndpoint) {
+    drupalkitOptions.userApiInitSetPasswordEndpoint = drupalkitOptions.userApiResetPasswordEndpoint;
+  }
+  if (drupalkitOptions.userApiUpdatePasswordEndpoint) {
+    drupalkitOptions.userApiSetPasswordEndpoint = drupalkitOptions.userApiUpdatePasswordEndpoint;
+  }
+  if (drupalkitOptions.userApiVerifyEmailEndpoint) {
+    drupalkitOptions.userApiInitSetEmailEndpoint = drupalkitOptions.userApiVerifyEmailEndpoint;
+  }
+  if (drupalkitOptions.userApiUpdateEmailEndpoint) {
+    drupalkitOptions.userApiSetEmailEndpoint = drupalkitOptions.userApiUpdateEmailEndpoint;
+  }
+
   const registrationEndpoint =
     drupalkitOptions.userApiRegistrationEndpoint ?? "/user-api/register";
-  const initAccountCancelEndpoint =
-    drupalkitOptions.userApiInitAccountCancelEndpoint ??
-    "/user-api/cancel-account/init";
+  const registerResendEmailEndpoint =
+    drupalkitOptions.userApiRegisterResendEmailEndpoint ??
+    "/user-api/register/resend-email";
+
   const cancelAccountEndpoint =
     drupalkitOptions.userApiCancelAccountEndpoint ?? "/user-api/cancel-account";
-  const resetPasswordEndpoint =
-    drupalkitOptions.userApiResetPasswordEndpoint ??
+  const initCancelAccountEndpoint =
+    drupalkitOptions.userApiInitCancelAccountEndpoint ??
+    "/user-api/cancel-account/init";
+
+  const initSetPasswordEndpoint =
+    drupalkitOptions.userApiInitSetPasswordEndpoint ??
     "/user-api/set-password/init";
-  const updatePasswordEndpoint =
-    drupalkitOptions.userApiUpdatePasswordEndpoint ?? "/user-api/set-password";
+  const setPasswordEndpoint =
+    drupalkitOptions.userApiSetPasswordEndpoint ?? "/user-api/set-password";
+
   const passwordlessLoginEndpoint =
     drupalkitOptions.userApiPasswordlessLoginEndpoint ??
     "/user-api/passwordless-login";
-  const updateEmailEndpoint =
-    drupalkitOptions.userApiUpdateEmailEndpoint ?? "/user-api/set-email";
-  const verifyEmailEndpoint =
-    drupalkitOptions.userApiVerifyEmailEndpoint ?? "/user-api/set-email/init";
-  const resendMailEndpoint =
-    drupalkitOptions.userApiResendMailEndpoint ??
-    "/user-api/register/resend-email";
+
+  const initSetEmailEndpoint =
+    drupalkitOptions.userApiInitSetEmailEndpoint ?? "/user-api/set-email/init";
+  const setEmailEndpoint =
+    drupalkitOptions.userApiSetEmailEndpoint ?? "/user-api/set-email";
 
   const headers = {
     "content-type": "application/json",
@@ -103,7 +112,7 @@ export const DrupalkitUserApi = (
   const initAccountCancel = async (
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
-    const url = drupalkit.buildUrl(initAccountCancelEndpoint);
+    const url = drupalkit.buildUrl(initCancelAccountEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(
       url,
@@ -168,7 +177,7 @@ export const DrupalkitUserApi = (
     email: string,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
-    const url = drupalkit.buildUrl(resetPasswordEndpoint);
+    const url = drupalkit.buildUrl(initSetPasswordEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(
       url,
@@ -202,7 +211,7 @@ export const DrupalkitUserApi = (
     currentPassword?: string,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
-    const url = drupalkit.buildUrl(updatePasswordEndpoint);
+    const url = drupalkit.buildUrl(setPasswordEndpoint);
 
     const payload: { newPassword: string; currentPassword?: string } = {
       newPassword,
@@ -278,7 +287,7 @@ export const DrupalkitUserApi = (
     email: string,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
-    const url = drupalkit.buildUrl(verifyEmailEndpoint);
+    const url = drupalkit.buildUrl(initSetEmailEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(
       url,
@@ -310,7 +319,7 @@ export const DrupalkitUserApi = (
     email: string,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SuccessResponse, DrupalkitError>> => {
-    const url = drupalkit.buildUrl(updateEmailEndpoint);
+    const url = drupalkit.buildUrl(setEmailEndpoint);
 
     const result = await drupalkit.request<SuccessResponse>(
       url,
@@ -343,7 +352,7 @@ export const DrupalkitUserApi = (
     operation: string,
     requestOptions?: OverrideableRequestOptions,
   ) => {
-    const url = drupalkit.buildUrl(resendMailEndpoint);
+    const url = drupalkit.buildUrl(registerResendEmailEndpoint);
 
     const result = await drupalkit.request<{ status: "success" }>(
       url,

--- a/packages/user-api/src/types.ts
+++ b/packages/user-api/src/types.ts
@@ -1,4 +1,106 @@
 /**
+ * Augment DrupalkitOptions and add custom configuration.
+ */
+declare module "@drupal-kit/core" {
+  interface DrupalkitOptions {
+    /**
+     * Endpoint path for the User API AdvancedRegistrationResource.
+     *
+     * @default '/user-api/register'
+     */
+    userApiRegistrationEndpoint?: string;
+    /**
+     * Endpoint path for the User API ResendRegisterEmailResource.
+     *
+     * @default '/user-api/register/resend-email'
+     */
+    userApiRegisterResendEmailEndpoint?: string;
+    /**
+     * Endpoint path for the User API InitCancelAccountResource.
+     *
+     * @default '/user-api/cancel-account/init'
+     */
+    userApiInitCancelAccountEndpoint?: string;
+    /**
+     * Endpoint path for the User API CancelAccountResource.
+     *
+     * @default '/user-api/cancel-account'
+     */
+    userApiCancelAccountEndpoint?: string;
+    /**
+     * Endpoint path for the User API InitSetPasswordResource.
+     *
+     * @default '/user-api/set-password/init'
+     */
+    userApiInitSetPasswordEndpoint?: string;
+    /**
+     * Endpoint path for the User API SetPasswordResource.
+     *
+     * @default '/user-api/set-password'
+     */
+    userApiSetPasswordEndpoint?: string;
+    /**
+     * Endpoint path for the User API PasswordlessLoginResource.
+     *
+     * @default '/user-api/passwordless-login'
+     */
+    userApiPasswordlessLoginEndpoint?: string;
+    /**
+     * Endpoint path for the User API InitSetEmailResource.
+     *
+     * @default '/user-api/set-email/init'
+     */
+    userApiInitSetEmailEndpoint?: string;
+    /**
+     * Endpoint path for the User API SetEmailResource.
+     *
+     * @default '/user-api/set-email'
+     */
+    userApiSetEmailEndpoint?: string;
+
+    //
+    // Deprecated properties.
+    // 
+
+    /**
+     * Endpoint path for the User API ResendRegisterEmailResource.
+     *
+     * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `userApiRegisterResendEmailEndpoint` instead.
+     */
+    userApiResendMailEndpoint?: string;
+    /**
+     * Endpoint path for the User API InitCancelAccountResource.
+     *
+     * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `userApiInitCancelAccountEndpoint` instead.
+     */
+    userApiInitAccountCancelEndpoint?: string;
+    /**
+     * Endpoint path for the User API InitSetPasswordResource.
+     *
+     * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `userApiInitSetPasswordEndpoint` instead.
+     */
+    userApiResetPasswordEndpoint?: string;
+    /**
+     * Endpoint path for the User API SetPasswordResource.
+     *
+     * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `userApiSetPasswordEndpoint` instead.
+     */
+    userApiUpdatePasswordEndpoint?: string;
+    /**
+     * Endpoint path for the User API InitSetEmailResource.
+     *
+     * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `userApiInitSetEmailEndpoint` instead.
+     */
+    userApiUpdateEmailEndpoint?: string;
+    /**
+     * Endpoint path for the User API SetEmailResource.
+     *
+     * @deprecated Deprecated in `0.9.3` will be removed in `1.0.0`. Use `userApiSetEmailEndpoint` instead.
+     */
+    userApiVerifyEmailEndpoint?: string;
+  }
+}
+/**
  * Augment this interface to include all fields
  * that are needed for registration.
  */

--- a/packages/user-api/src/types.ts
+++ b/packages/user-api/src/types.ts
@@ -60,7 +60,7 @@ declare module "@drupal-kit/core" {
 
     //
     // Deprecated properties.
-    // 
+    //
 
     /**
      * Endpoint path for the User API ResendRegisterEmailResource.

--- a/packages/user-api/src/types.ts
+++ b/packages/user-api/src/types.ts
@@ -40,6 +40,18 @@ declare module "@drupal-kit/core" {
      */
     userApiSetPasswordEndpoint?: string;
     /**
+     * Endpoint path for the User API InitSetPasswordResource.
+     *
+     * @default '/user-api/set-password/init'
+     */
+    userApiInitUnsetPasswordEndpoint?: string;
+    /**
+     * Endpoint path for the User API SetPasswordResource.
+     *
+     * @default '/user-api/set-password'
+     */
+    userApiUnsetPasswordEndpoint?: string;
+    /**
      * Endpoint path for the User API PasswordlessLoginResource.
      *
      * @default '/user-api/passwordless-login'

--- a/packages/user-api/src/utils.ts
+++ b/packages/user-api/src/utils.ts
@@ -1,0 +1,17 @@
+import coreDeprecate from "util-deprecate";
+
+/**
+ * Wrapper arround the util-deprecate deprecate function.
+ *
+ * Generates the deprecation proper message.
+ *
+ * @param fn - The function to deprecate.
+ * @param deprecatedFuncName - The name of the deprecated function.
+ */
+// eslint-disable-next-line
+export function deprecate(fn: Function, deprecatedFuncName: string) {
+  return coreDeprecate(
+    fn,
+    `drupalkit.userApi.${deprecatedFuncName}() is deprecated, use drupalkit.userApi.${fn.name}() instead.`,
+  );
+}

--- a/packages/user-api/tests/DrupalkitUserApi.test.ts
+++ b/packages/user-api/tests/DrupalkitUserApi.test.ts
@@ -150,7 +150,7 @@ test.serial("Init account cancel", async (t) => {
   const drupalkit = createDrupalkit();
 
   server.use(
-    rest.post("*/user-api/init-account-cancel", async (req, res, ctx) => {
+    rest.post("*/user-api/cancel-account/init", async (req, res, ctx) => {
       t.is(req.headers.get("content-type"), "application/json");
 
       return res(ctx.json(successResponse));
@@ -174,7 +174,7 @@ test.serial("Init account cancel with custom request options", async (t) => {
   });
 
   server.use(
-    rest.post("*/user-api/init-account-cancel", async (req, res, ctx) => {
+    rest.post("*/user-api/cancel-account/init", async (req, res, ctx) => {
       t.is(req.headers.get("X-Custom"), "1");
 
       return res(ctx.json(successResponse));
@@ -192,11 +192,11 @@ test.serial("Init account cancel with custom request options", async (t) => {
 test.serial("Init account cancel with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
-    userApiInitAccountCancelEndpoint: "/custom/init-account-cancel",
+    userApiInitAccountCancelEndpoint: "/custom/cancel-account/init",
   });
 
   server.use(
-    rest.post("*/custom/init-account-cancel", async (req, res, ctx) =>
+    rest.post("*/custom/cancel-account/init", async (req, res, ctx) =>
       res(ctx.json(successResponse)),
     ),
   );
@@ -210,7 +210,7 @@ test.serial("Handle error while init account cancel", async (t) => {
   const drupalkit = createDrupalkit();
 
   server.use(
-    rest.post("*/user-api/init-account-cancel", async (req, res, ctx) =>
+    rest.post("*/user-api/cancel-account/init", async (req, res, ctx) =>
       res(ctx.status(400)),
     ),
   );
@@ -311,7 +311,7 @@ test.serial("Reset password", async (t) => {
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/user-api/reset-password", async (req, res, ctx) => {
+    rest.post("*/user-api/set-password/init", async (req, res, ctx) => {
       t.is(req.headers.get("content-type"), "application/json");
 
       t.deepEqual(await req.json(), { email });
@@ -338,7 +338,7 @@ test.serial("Reset password with custom request options", async (t) => {
   });
 
   server.use(
-    rest.post("*/user-api/reset-password", async (req, res, ctx) => {
+    rest.post("*/user-api/set-password/init", async (req, res, ctx) => {
       t.is(req.headers.get("X-Custom"), "1");
 
       return res(ctx.json(successResponse));
@@ -356,12 +356,12 @@ test.serial("Reset password with custom request options", async (t) => {
 test.serial("Reset password with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
-    userApiResetPasswordEndpoint: "/custom/reset-password",
+    userApiResetPasswordEndpoint: "/custom/set-password/init",
   });
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/custom/reset-password", async (_req, res, ctx) =>
+    rest.post("*/custom/set-password/init", async (_req, res, ctx) =>
       res(ctx.json(successResponse)),
     ),
   );
@@ -376,7 +376,7 @@ test.serial("Handle error while resetting password", async (t) => {
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/user-api/reset-password", async (_req, res, ctx) =>
+    rest.post("*/user-api/set-password/init", async (_req, res, ctx) =>
       res(ctx.status(400)),
     ),
   );
@@ -397,7 +397,7 @@ test.serial("Update password", async (t) => {
   const newPassword = "new-password";
 
   server.use(
-    rest.post("*/user-api/update-password", async (req, res, ctx) => {
+    rest.post("*/user-api/set-password", async (req, res, ctx) => {
       t.is(req.headers.get("content-type"), "application/json");
 
       t.deepEqual(await req.json(), { newPassword });
@@ -424,7 +424,7 @@ test.serial("Update password with custom request options", async (t) => {
   });
 
   server.use(
-    rest.post("*/user-api/update-password", async (req, res, ctx) => {
+    rest.post("*/user-api/set-password", async (req, res, ctx) => {
       t.is(req.headers.get("X-Custom"), "1");
 
       return res(ctx.json(successResponse));
@@ -442,12 +442,12 @@ test.serial("Update password with custom request options", async (t) => {
 test.serial("Update password with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
-    userApiUpdatePasswordEndpoint: "/custom/update-password",
+    userApiUpdatePasswordEndpoint: "/custom/set-password",
   });
   const newPassword = "new-password";
 
   server.use(
-    rest.post("*/custom/update-password", async (_req, res, ctx) =>
+    rest.post("*/custom/set-password", async (_req, res, ctx) =>
       res(ctx.json(successResponse)),
     ),
   );
@@ -462,7 +462,7 @@ test.serial("Handle error while updating password", async (t) => {
   const newPassword = "new-password";
 
   server.use(
-    rest.post("*/user-api/update-password", async (_req, res, ctx) =>
+    rest.post("*/user-api/set-password", async (_req, res, ctx) =>
       res(ctx.status(400)),
     ),
   );
@@ -569,7 +569,7 @@ test.serial("Verify email", async (t) => {
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/user-api/verify-email", async (req, res, ctx) => {
+    rest.post("*/user-api/set-email/init", async (req, res, ctx) => {
       t.is(req.headers.get("content-type"), "application/json");
 
       t.deepEqual(await req.json(), { email });
@@ -596,7 +596,7 @@ test.serial("Verify email with custom request options", async (t) => {
   });
 
   server.use(
-    rest.post("*/user-api/verify-email", async (req, res, ctx) => {
+    rest.post("*/user-api/set-email/init", async (req, res, ctx) => {
       t.is(req.headers.get("X-Custom"), "1");
 
       return res(ctx.json(successResponse));
@@ -614,12 +614,12 @@ test.serial("Verify email with custom request options", async (t) => {
 test.serial("Verify email with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
-    userApiVerifyEmailEndpoint: "/custom/verify-email",
+    userApiVerifyEmailEndpoint: "/custom/set-email/init",
   });
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/custom/verify-email", async (_req, res, ctx) =>
+    rest.post("*/custom/set-email/init", async (_req, res, ctx) =>
       res(ctx.json(successResponse)),
     ),
   );
@@ -634,7 +634,7 @@ test.serial("Handle error while verifying email", async (t) => {
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/user-api/verify-email", async (_req, res, ctx) =>
+    rest.post("*/user-api/set-email/init", async (_req, res, ctx) =>
       res(ctx.status(400)),
     ),
   );
@@ -655,7 +655,7 @@ test.serial("Update email", async (t) => {
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/user-api/update-email", async (req, res, ctx) => {
+    rest.post("*/user-api/set-email", async (req, res, ctx) => {
       t.is(req.headers.get("content-type"), "application/json");
 
       t.deepEqual(await req.json(), { email });
@@ -682,7 +682,7 @@ test.serial("Update email with custom request options", async (t) => {
   });
 
   server.use(
-    rest.post("*/user-api/update-email", async (req, res, ctx) => {
+    rest.post("*/user-api/set-email", async (req, res, ctx) => {
       t.is(req.headers.get("X-Custom"), "1");
 
       return res(ctx.json(successResponse));
@@ -700,12 +700,12 @@ test.serial("Update email with custom request options", async (t) => {
 test.serial("Update email with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
-    userApiUpdateEmailEndpoint: "/custom/update-email",
+    userApiUpdateEmailEndpoint: "/custom/set-email",
   });
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/custom/update-email", async (_req, res, ctx) =>
+    rest.post("*/custom/set-email", async (_req, res, ctx) =>
       res(ctx.json(successResponse)),
     ),
   );
@@ -720,7 +720,7 @@ test.serial("Handle error while updating email", async (t) => {
   const email = "JzWZg@example.com";
 
   server.use(
-    rest.post("*/user-api/update-email", async (_req, res, ctx) =>
+    rest.post("*/user-api/set-email", async (_req, res, ctx) =>
       res(ctx.status(400)),
     ),
   );
@@ -742,7 +742,7 @@ test.serial("Resend verification email", async (t) => {
   const operation = "register";
 
   server.use(
-    rest.post("*/user-api/resend-mail", async (req, res, ctx) => {
+    rest.post("*/user-api/register/resend-email", async (req, res, ctx) => {
       t.is(req.headers.get("content-type"), "application/json");
 
       t.deepEqual(await req.json(), { email, operation });
@@ -775,7 +775,7 @@ test.serial(
     });
 
     server.use(
-      rest.post("*/user-api/resend-mail", async (req, res, ctx) => {
+      rest.post("*/user-api/register/resend-email", async (req, res, ctx) => {
         t.is(req.headers.get("X-Custom"), "1");
 
         return res(ctx.json(successResponse));
@@ -794,13 +794,13 @@ test.serial(
 test.serial("Resend verification email with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
-    userApiResendMailEndpoint: "/custom/resend-mail",
+    userApiResendMailEndpoint: "/custom/register/resend-email",
   });
   const email = "JzWZg@example.com";
   const operation = "register";
 
   server.use(
-    rest.post("*/custom/resend-mail", async (_req, res, ctx) =>
+    rest.post("*/custom/register/resend-email", async (_req, res, ctx) =>
       res(ctx.json(successResponse)),
     ),
   );
@@ -819,7 +819,7 @@ test.serial("Handle error while resending verification email", async (t) => {
   const operation = "register";
 
   server.use(
-    rest.post("*/user-api/resend-mail", async (_req, res, ctx) =>
+    rest.post("*/user-api/register/resend-email", async (_req, res, ctx) =>
       res(ctx.status(400)),
     ),
   );

--- a/packages/user-api/tests/DrupalkitUserApi.test.ts
+++ b/packages/user-api/tests/DrupalkitUserApi.test.ts
@@ -638,6 +638,198 @@ test.serial("Handle error while set password", async (t) => {
 });
 
 /**
+ * Init unset password
+ */
+
+test.serial("Init unset password", async (t) => {
+  t.plan(3);
+
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+
+  server.use(
+    rest.post("*/user-api/unset-password/init", async (req, res, ctx) => {
+      t.is(req.headers.get("content-type"), "application/json");
+
+      t.deepEqual(await req.json(), { email });
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  const result = await drupalkit.userApi.initUnsetPassword(email);
+
+  const res = result.unwrap();
+
+  t.deepEqual(res, successResponse);
+});
+
+test.serial("Init unset password with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/unset-password/init", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.initUnsetPassword(email, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
+});
+
+test.serial("Init unset password with custom endpoint", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiInitUnsetPasswordEndpoint: "/custom/unset-password/init",
+  });
+  const email = "JzWZg@example.com";
+
+  server.use(
+    rest.post("*/custom/unset-password/init", async (_req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.initUnsetPassword(email);
+
+  t.assert(result.ok);
+});
+
+test.serial("Handle error while init unset password", async (t) => {
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+
+  server.use(
+    rest.post("*/user-api/unset-password/init", async (_req, res, ctx) =>
+      res(ctx.status(400)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.initUnsetPassword(email);
+
+  t.assert(result.err);
+});
+
+/**
+ * Unset password
+ */
+
+test.serial("Unset password with verification", async (t) => {
+  t.plan(3);
+
+  const drupalkit = createDrupalkit();
+
+  server.use(
+    rest.post("*/user-api/unset-password", async (req, res, ctx) => {
+      t.is(req.headers.get("content-type"), "application/json");
+
+      t.deepEqual(await req.json(), {});
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  const result = await drupalkit.userApi.unsetPassword();
+
+  const res = result.unwrap();
+
+  t.deepEqual(res, successResponse);
+});
+
+test.serial("Unset password with currentPassword", async (t) => {
+  t.plan(3);
+
+  const drupalkit = createDrupalkit();
+  const currentPassword = "abc123";
+
+  server.use(
+    rest.post("*/user-api/unset-password", async (req, res, ctx) => {
+      t.is(req.headers.get("content-type"), "application/json");
+
+      t.deepEqual(await req.json(), { currentPassword });
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  const result = await drupalkit.userApi.unsetPassword(currentPassword);
+
+  const res = result.unwrap();
+
+  t.deepEqual(res, successResponse);
+});
+
+test.serial("Unset password with custom request options", async (t) => {
+  t.plan(2);
+
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
+
+  server.use(
+    rest.post("*/user-api/unset-password", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  await drupalkit.userApi.unsetPassword(undefined, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
+});
+
+test.serial("Unset password with custom endpoint", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiUnsetPasswordEndpoint: "/custom/unset-password",
+  });
+
+  server.use(
+    rest.post("*/custom/unset-password", async (_req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.unsetPassword();
+
+  t.assert(result.ok);
+});
+
+test.serial("Handle error while unset password", async (t) => {
+  const drupalkit = createDrupalkit();
+  const newPassword = "new-password";
+
+  server.use(
+    rest.post("*/user-api/unset-password", async (_req, res, ctx) =>
+      res(ctx.status(400)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.unsetPassword(newPassword);
+
+  t.assert(result.err);
+});
+
+/**
  * Passwordless login
  */
 

--- a/packages/user-api/tests/DrupalkitUserApi.test.ts
+++ b/packages/user-api/tests/DrupalkitUserApi.test.ts
@@ -140,7 +140,6 @@ test.serial("Handle register error", async (t) => {
   t.assert(result.err);
 });
 
-
 /**
  * Resend register email.
  */
@@ -162,45 +161,39 @@ test.serial("Resend register email", async (t) => {
     }),
   );
 
-  const result = await drupalkit.userApi.resendVerificationEmail(
-    email,
-    operation,
-  );
+  const result = await drupalkit.userApi.resendRegisterEmail(email, operation);
 
   const res = result.unwrap();
 
   t.deepEqual(res, successResponse);
 });
 
-test.serial(
-  "Resend register email with custom request options",
-  async (t) => {
-    t.plan(2);
+test.serial("Resend register email with custom request options", async (t) => {
+  t.plan(2);
 
-    const drupalkit = createDrupalkit();
-    const email = "JzWZg@example.com";
-    const operation = "register";
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+  const operation = "register";
 
-    drupalkit.hook.before("request", (options) => {
-      t.is(options.cache, "no-cache");
-    });
+  drupalkit.hook.before("request", (options) => {
+    t.is(options.cache, "no-cache");
+  });
 
-    server.use(
-      rest.post("*/user-api/register/resend-email", async (req, res, ctx) => {
-        t.is(req.headers.get("X-Custom"), "1");
+  server.use(
+    rest.post("*/user-api/register/resend-email", async (req, res, ctx) => {
+      t.is(req.headers.get("X-Custom"), "1");
 
-        return res(ctx.json(successResponse));
-      }),
-    );
+      return res(ctx.json(successResponse));
+    }),
+  );
 
-    await drupalkit.userApi.resendVerificationEmail(email, operation, {
-      cache: "no-cache",
-      headers: {
-        "X-Custom": "1",
-      },
-    });
-  },
-);
+  await drupalkit.userApi.resendRegisterEmail(email, operation, {
+    cache: "no-cache",
+    headers: {
+      "X-Custom": "1",
+    },
+  });
+});
 
 test.serial("Resend register email with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
@@ -216,10 +209,7 @@ test.serial("Resend register email with custom endpoint", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.resendVerificationEmail(
-    email,
-    operation,
-  );
+  const result = await drupalkit.userApi.resendRegisterEmail(email, operation);
 
   t.assert(result.ok);
 });
@@ -257,16 +247,13 @@ test.serial("Handle error while resend register email", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.resendVerificationEmail(
-    email,
-    operation,
-  );
+  const result = await drupalkit.userApi.resendRegisterEmail(email, operation);
 
   t.assert(result.err);
 });
 
 /**
- * initAccountCancel().
+ * initCancelAccount().
  */
 
 test.serial("Init cancel account", async (t) => {
@@ -282,7 +269,7 @@ test.serial("Init cancel account", async (t) => {
     }),
   );
 
-  const result = await drupalkit.userApi.initAccountCancel();
+  const result = await drupalkit.userApi.initCancelAccount();
 
   const res = result.unwrap();
 
@@ -306,7 +293,7 @@ test.serial("Init cancel account with custom request options", async (t) => {
     }),
   );
 
-  await drupalkit.userApi.initAccountCancel({
+  await drupalkit.userApi.initCancelAccount({
     cache: "no-cache",
     headers: {
       "X-Custom": "1",
@@ -326,7 +313,7 @@ test.serial("Init cancel account with custom endpoint", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.initAccountCancel();
+  const result = await drupalkit.userApi.initCancelAccount();
 
   t.assert(result.ok);
 });
@@ -357,7 +344,7 @@ test.serial("Handle error while init cancel account", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.initAccountCancel();
+  const result = await drupalkit.userApi.initCancelAccount();
 
   t.assert(result.err);
 });
@@ -462,7 +449,7 @@ test.serial("Init set password", async (t) => {
     }),
   );
 
-  const result = await drupalkit.userApi.resetPassword(email);
+  const result = await drupalkit.userApi.initSetPassword(email);
 
   const res = result.unwrap();
 
@@ -487,7 +474,7 @@ test.serial("Init set password with custom request options", async (t) => {
     }),
   );
 
-  await drupalkit.userApi.resetPassword(email, {
+  await drupalkit.userApi.initSetPassword(email, {
     cache: "no-cache",
     headers: {
       "X-Custom": "1",
@@ -508,7 +495,7 @@ test.serial("Init set password with custom endpoint", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.resetPassword(email);
+  const result = await drupalkit.userApi.initSetPassword(email);
 
   t.assert(result.ok);
 });
@@ -541,7 +528,7 @@ test.serial("Handle error while init set password", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.resetPassword(email);
+  const result = await drupalkit.userApi.initSetPassword(email);
 
   t.assert(result.err);
 });
@@ -566,7 +553,7 @@ test.serial("Set password", async (t) => {
     }),
   );
 
-  const result = await drupalkit.userApi.updatePassword(newPassword);
+  const result = await drupalkit.userApi.setPassword(newPassword);
 
   const res = result.unwrap();
 
@@ -591,7 +578,7 @@ test.serial("Set password with custom request options", async (t) => {
     }),
   );
 
-  await drupalkit.userApi.updatePassword(newPassword, undefined, {
+  await drupalkit.userApi.setPassword(newPassword, undefined, {
     cache: "no-cache",
     headers: {
       "X-Custom": "1",
@@ -612,7 +599,7 @@ test.serial("Set password with custom endpoint", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.updatePassword(newPassword);
+  const result = await drupalkit.userApi.setPassword(newPassword);
 
   t.assert(result.ok);
 });
@@ -645,7 +632,7 @@ test.serial("Handle error while set password", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.updatePassword(newPassword);
+  const result = await drupalkit.userApi.setPassword(newPassword);
 
   t.assert(result.err);
 });
@@ -756,7 +743,7 @@ test.serial("Init set email", async (t) => {
     }),
   );
 
-  const result = await drupalkit.userApi.verifyEmail(email);
+  const result = await drupalkit.userApi.initSetEmail(email);
 
   const res = result.unwrap();
 
@@ -781,7 +768,7 @@ test.serial("Init set email with custom request options", async (t) => {
     }),
   );
 
-  await drupalkit.userApi.verifyEmail(email, {
+  await drupalkit.userApi.initSetEmail(email, {
     cache: "no-cache",
     headers: {
       "X-Custom": "1",
@@ -802,7 +789,7 @@ test.serial("Init set email with custom endpoint", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.verifyEmail(email);
+  const result = await drupalkit.userApi.initSetEmail(email);
 
   t.assert(result.ok);
 });
@@ -835,7 +822,7 @@ test.serial("Handle error while init set email", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.verifyEmail(email);
+  const result = await drupalkit.userApi.initSetEmail(email);
 
   t.assert(result.err);
 });
@@ -860,7 +847,7 @@ test.serial("Set email", async (t) => {
     }),
   );
 
-  const result = await drupalkit.userApi.updateEmail(email);
+  const result = await drupalkit.userApi.setEmail(email);
 
   const res = result.unwrap();
 
@@ -885,7 +872,7 @@ test.serial("Set email with custom request options", async (t) => {
     }),
   );
 
-  await drupalkit.userApi.updateEmail(email, {
+  await drupalkit.userApi.setEmail(email, {
     cache: "no-cache",
     headers: {
       "X-Custom": "1",
@@ -906,7 +893,7 @@ test.serial("Set email with custom endpoint", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.updateEmail(email);
+  const result = await drupalkit.userApi.setEmail(email);
 
   t.assert(result.ok);
 });
@@ -939,7 +926,7 @@ test.serial("Handle error while set email", async (t) => {
     ),
   );
 
-  const result = await drupalkit.userApi.updateEmail(email);
+  const result = await drupalkit.userApi.setEmail(email);
 
   t.assert(result.err);
 });

--- a/packages/user-api/tests/DrupalkitUserApi.test.ts
+++ b/packages/user-api/tests/DrupalkitUserApi.test.ts
@@ -99,7 +99,7 @@ test.serial("Register with custom request options", async (t) => {
   });
 });
 
-test.serial("Register with explicit endpoint", async (t) => {
+test.serial("Register with custom endpoint", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
     userApiRegistrationEndpoint: "/custom/register",
@@ -140,11 +140,136 @@ test.serial("Handle register error", async (t) => {
   t.assert(result.err);
 });
 
+
+/**
+ * Resend register email.
+ */
+
+test.serial("Resend register email", async (t) => {
+  t.plan(3);
+
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+  const operation = "register";
+
+  server.use(
+    rest.post("*/user-api/register/resend-email", async (req, res, ctx) => {
+      t.is(req.headers.get("content-type"), "application/json");
+
+      t.deepEqual(await req.json(), { email, operation });
+
+      return res(ctx.json(successResponse));
+    }),
+  );
+
+  const result = await drupalkit.userApi.resendVerificationEmail(
+    email,
+    operation,
+  );
+
+  const res = result.unwrap();
+
+  t.deepEqual(res, successResponse);
+});
+
+test.serial(
+  "Resend register email with custom request options",
+  async (t) => {
+    t.plan(2);
+
+    const drupalkit = createDrupalkit();
+    const email = "JzWZg@example.com";
+    const operation = "register";
+
+    drupalkit.hook.before("request", (options) => {
+      t.is(options.cache, "no-cache");
+    });
+
+    server.use(
+      rest.post("*/user-api/register/resend-email", async (req, res, ctx) => {
+        t.is(req.headers.get("X-Custom"), "1");
+
+        return res(ctx.json(successResponse));
+      }),
+    );
+
+    await drupalkit.userApi.resendVerificationEmail(email, operation, {
+      cache: "no-cache",
+      headers: {
+        "X-Custom": "1",
+      },
+    });
+  },
+);
+
+test.serial("Resend register email with custom endpoint", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiRegisterResendEmailEndpoint: "/custom/register/resend-email",
+  });
+  const email = "JzWZg@example.com";
+  const operation = "register";
+
+  server.use(
+    rest.post("*/custom/register/resend-email", async (_req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.resendVerificationEmail(
+    email,
+    operation,
+  );
+
+  t.assert(result.ok);
+});
+
+test.serial("Resend register email - deprecated version", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiResendMailEndpoint: "/custom/register/resend-email",
+  });
+  const email = "JzWZg@example.com";
+  const operation = "register";
+
+  server.use(
+    rest.post("*/custom/register/resend-email", async (_req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.resendVerificationEmail(
+    email,
+    operation,
+  );
+
+  t.assert(result.ok);
+});
+
+test.serial("Handle error while resend register email", async (t) => {
+  const drupalkit = createDrupalkit();
+  const email = "JzWZg@example.com";
+  const operation = "register";
+
+  server.use(
+    rest.post("*/user-api/register/resend-email", async (_req, res, ctx) =>
+      res(ctx.status(400)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.resendVerificationEmail(
+    email,
+    operation,
+  );
+
+  t.assert(result.err);
+});
+
 /**
  * initAccountCancel().
  */
 
-test.serial("Init account cancel", async (t) => {
+test.serial("Init cancel account", async (t) => {
   t.plan(2);
 
   const drupalkit = createDrupalkit();
@@ -164,7 +289,7 @@ test.serial("Init account cancel", async (t) => {
   t.deepEqual(res, successResponse);
 });
 
-test.serial("Init account cancel with custom request options", async (t) => {
+test.serial("Init cancel account with custom request options", async (t) => {
   t.plan(2);
 
   const drupalkit = createDrupalkit();
@@ -189,7 +314,24 @@ test.serial("Init account cancel with custom request options", async (t) => {
   });
 });
 
-test.serial("Init account cancel with custom endpoint", async (t) => {
+test.serial("Init cancel account with custom endpoint", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiInitCancelAccountEndpoint: "/custom/cancel-account/init",
+  });
+
+  server.use(
+    rest.post("*/custom/cancel-account/init", async (req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.initAccountCancel();
+
+  t.assert(result.ok);
+});
+
+test.serial("Init cancel account - deprecated version", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
     userApiInitAccountCancelEndpoint: "/custom/cancel-account/init",
@@ -206,7 +348,7 @@ test.serial("Init account cancel with custom endpoint", async (t) => {
   t.assert(result.ok);
 });
 
-test.serial("Handle error while init account cancel", async (t) => {
+test.serial("Handle error while init cancel account", async (t) => {
   const drupalkit = createDrupalkit();
 
   server.use(
@@ -301,10 +443,10 @@ test.serial("Handle error while cancel account", async (t) => {
 });
 
 /**
- * Reset password
+ * Init set password
  */
 
-test.serial("Reset password", async (t) => {
+test.serial("Init set password", async (t) => {
   t.plan(3);
 
   const drupalkit = createDrupalkit();
@@ -327,7 +469,7 @@ test.serial("Reset password", async (t) => {
   t.deepEqual(res, successResponse);
 });
 
-test.serial("Reset password with custom request options", async (t) => {
+test.serial("Init set password with custom request options", async (t) => {
   t.plan(2);
 
   const drupalkit = createDrupalkit();
@@ -353,7 +495,25 @@ test.serial("Reset password with custom request options", async (t) => {
   });
 });
 
-test.serial("Reset password with custom endpoint", async (t) => {
+test.serial("Init set password with custom endpoint", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiInitSetPasswordEndpoint: "/custom/set-password/init",
+  });
+  const email = "JzWZg@example.com";
+
+  server.use(
+    rest.post("*/custom/set-password/init", async (_req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.resetPassword(email);
+
+  t.assert(result.ok);
+});
+
+test.serial("Init set password - deprecated version", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
     userApiResetPasswordEndpoint: "/custom/set-password/init",
@@ -371,7 +531,7 @@ test.serial("Reset password with custom endpoint", async (t) => {
   t.assert(result.ok);
 });
 
-test.serial("Handle error while resetting password", async (t) => {
+test.serial("Handle error while init set password", async (t) => {
   const drupalkit = createDrupalkit();
   const email = "JzWZg@example.com";
 
@@ -387,10 +547,10 @@ test.serial("Handle error while resetting password", async (t) => {
 });
 
 /**
- * Update password
+ * Set password
  */
 
-test.serial("Update password", async (t) => {
+test.serial("Set password", async (t) => {
   t.plan(3);
 
   const drupalkit = createDrupalkit();
@@ -413,7 +573,7 @@ test.serial("Update password", async (t) => {
   t.deepEqual(res, successResponse);
 });
 
-test.serial("Update password with custom request options", async (t) => {
+test.serial("Set password with custom request options", async (t) => {
   t.plan(2);
 
   const drupalkit = createDrupalkit();
@@ -439,7 +599,25 @@ test.serial("Update password with custom request options", async (t) => {
   });
 });
 
-test.serial("Update password with custom endpoint", async (t) => {
+test.serial("Set password with custom endpoint", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiSetPasswordEndpoint: "/custom/set-password",
+  });
+  const newPassword = "new-password";
+
+  server.use(
+    rest.post("*/custom/set-password", async (_req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.updatePassword(newPassword);
+
+  t.assert(result.ok);
+});
+
+test.serial("Set password - deprecated version", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
     userApiUpdatePasswordEndpoint: "/custom/set-password",
@@ -457,7 +635,7 @@ test.serial("Update password with custom endpoint", async (t) => {
   t.assert(result.ok);
 });
 
-test.serial("Handle error while updating password", async (t) => {
+test.serial("Handle error while set password", async (t) => {
   const drupalkit = createDrupalkit();
   const newPassword = "new-password";
 
@@ -559,10 +737,10 @@ test.serial("Handle error while passwordless login", async (t) => {
 });
 
 /**
- * Verify email
+ * Init set email
  */
 
-test.serial("Verify email", async (t) => {
+test.serial("Init set email", async (t) => {
   t.plan(3);
 
   const drupalkit = createDrupalkit();
@@ -585,7 +763,7 @@ test.serial("Verify email", async (t) => {
   t.deepEqual(res, successResponse);
 });
 
-test.serial("Verify email with custom request options", async (t) => {
+test.serial("Init set email with custom request options", async (t) => {
   t.plan(2);
 
   const drupalkit = createDrupalkit();
@@ -611,7 +789,25 @@ test.serial("Verify email with custom request options", async (t) => {
   });
 });
 
-test.serial("Verify email with custom endpoint", async (t) => {
+test.serial("Init set email with custom endpoint", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiInitSetEmailEndpoint: "/custom/set-email/init",
+  });
+  const email = "JzWZg@example.com";
+
+  server.use(
+    rest.post("*/custom/set-email/init", async (_req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.verifyEmail(email);
+
+  t.assert(result.ok);
+});
+
+test.serial("Init set email - deprecated version", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
     userApiVerifyEmailEndpoint: "/custom/set-email/init",
@@ -629,7 +825,7 @@ test.serial("Verify email with custom endpoint", async (t) => {
   t.assert(result.ok);
 });
 
-test.serial("Handle error while verifying email", async (t) => {
+test.serial("Handle error while init set email", async (t) => {
   const drupalkit = createDrupalkit();
   const email = "JzWZg@example.com";
 
@@ -645,10 +841,10 @@ test.serial("Handle error while verifying email", async (t) => {
 });
 
 /**
- * Update email
+ * Set email
  */
 
-test.serial("Update email", async (t) => {
+test.serial("Set email", async (t) => {
   t.plan(3);
 
   const drupalkit = createDrupalkit();
@@ -671,7 +867,7 @@ test.serial("Update email", async (t) => {
   t.deepEqual(res, successResponse);
 });
 
-test.serial("Update email with custom request options", async (t) => {
+test.serial("Set email with custom request options", async (t) => {
   t.plan(2);
 
   const drupalkit = createDrupalkit();
@@ -697,7 +893,25 @@ test.serial("Update email with custom request options", async (t) => {
   });
 });
 
-test.serial("Update email with custom endpoint", async (t) => {
+test.serial("Set email with custom endpoint", async (t) => {
+  const drupalkit = createDrupalkit({
+    baseUrl: BASE_URL,
+    userApiSetEmailEndpoint: "/custom/set-email",
+  });
+  const email = "JzWZg@example.com";
+
+  server.use(
+    rest.post("*/custom/set-email", async (_req, res, ctx) =>
+      res(ctx.json(successResponse)),
+    ),
+  );
+
+  const result = await drupalkit.userApi.updateEmail(email);
+
+  t.assert(result.ok);
+});
+
+test.serial("Set email - deprecated version", async (t) => {
   const drupalkit = createDrupalkit({
     baseUrl: BASE_URL,
     userApiUpdateEmailEndpoint: "/custom/set-email",
@@ -715,7 +929,7 @@ test.serial("Update email with custom endpoint", async (t) => {
   t.assert(result.ok);
 });
 
-test.serial("Handle error while updating email", async (t) => {
+test.serial("Handle error while set email", async (t) => {
   const drupalkit = createDrupalkit();
   const email = "JzWZg@example.com";
 
@@ -726,108 +940,6 @@ test.serial("Handle error while updating email", async (t) => {
   );
 
   const result = await drupalkit.userApi.updateEmail(email);
-
-  t.assert(result.err);
-});
-
-/**
- * Resend verification email.
- */
-
-test.serial("Resend verification email", async (t) => {
-  t.plan(3);
-
-  const drupalkit = createDrupalkit();
-  const email = "JzWZg@example.com";
-  const operation = "register";
-
-  server.use(
-    rest.post("*/user-api/register/resend-email", async (req, res, ctx) => {
-      t.is(req.headers.get("content-type"), "application/json");
-
-      t.deepEqual(await req.json(), { email, operation });
-
-      return res(ctx.json(successResponse));
-    }),
-  );
-
-  const result = await drupalkit.userApi.resendVerificationEmail(
-    email,
-    operation,
-  );
-
-  const res = result.unwrap();
-
-  t.deepEqual(res, successResponse);
-});
-
-test.serial(
-  "Resend verification email with custom request options",
-  async (t) => {
-    t.plan(2);
-
-    const drupalkit = createDrupalkit();
-    const email = "JzWZg@example.com";
-    const operation = "register";
-
-    drupalkit.hook.before("request", (options) => {
-      t.is(options.cache, "no-cache");
-    });
-
-    server.use(
-      rest.post("*/user-api/register/resend-email", async (req, res, ctx) => {
-        t.is(req.headers.get("X-Custom"), "1");
-
-        return res(ctx.json(successResponse));
-      }),
-    );
-
-    await drupalkit.userApi.resendVerificationEmail(email, operation, {
-      cache: "no-cache",
-      headers: {
-        "X-Custom": "1",
-      },
-    });
-  },
-);
-
-test.serial("Resend verification email with custom endpoint", async (t) => {
-  const drupalkit = createDrupalkit({
-    baseUrl: BASE_URL,
-    userApiResendMailEndpoint: "/custom/register/resend-email",
-  });
-  const email = "JzWZg@example.com";
-  const operation = "register";
-
-  server.use(
-    rest.post("*/custom/register/resend-email", async (_req, res, ctx) =>
-      res(ctx.json(successResponse)),
-    ),
-  );
-
-  const result = await drupalkit.userApi.resendVerificationEmail(
-    email,
-    operation,
-  );
-
-  t.assert(result.ok);
-});
-
-test.serial("Handle error while resending verification email", async (t) => {
-  const drupalkit = createDrupalkit();
-  const email = "JzWZg@example.com";
-  const operation = "register";
-
-  server.use(
-    rest.post("*/user-api/register/resend-email", async (_req, res, ctx) =>
-      res(ctx.status(400)),
-    ),
-  );
-
-  const result = await drupalkit.userApi.resendVerificationEmail(
-    email,
-    operation,
-  );
 
   t.assert(result.err);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
       '@wunderwerk/ts-functional':
         specifier: 1.0.0-beta.2
         version: 1.0.0-beta.2
+      util-deprecate:
+        specifier: ^1.0.2
+        version: 1.0.2
     devDependencies:
       '@drupal-kit/config-typescript':
         specifier: workspace:0.9.2
@@ -379,6 +382,9 @@ importers:
       '@swc/core':
         specifier: ^1.3.58
         version: 1.3.58
+      '@types/util-deprecate':
+        specifier: ^1.0.3
+        version: 1.0.3
       ava:
         specifier: ^5.2.0
         version: 5.2.0
@@ -1672,6 +1678,10 @@ packages:
     resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
     dependencies:
       '@types/node': 20.1.7
+    dev: true
+
+  /@types/util-deprecate@1.0.3:
+    resolution: {integrity: sha512-tS4Vw2qY1XJnS+ZL4wgzyJprahEFBgg72NlC8lyY7/RWmS9cqz5gnxta9Mv9/Zla/wXBDrcNpiLLMv/4+5hokw==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.40.0)(typescript@5.0.4):
@@ -5679,7 +5689,6 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
 
   /util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}


### PR DESCRIPTION
Closes #63 

Deprecates the following `userApi` options:

- `resendVerificationEmail`
- `initAccountCancel`
- `resetPassword`
- `updatePassword`
- `verifyEmail`
- `updateEmail`

Alongside that, the following `DrupalkitOptions` are also deprecated:

- `userApiResendMailEndpoint`
- `userApiInitAccountCancelEndpoint`
- `userApiResetPasswordEndpoint`
- `userApiUpdatePasswordEndpoint`
- `userApiVerifyEmailEndpoint`
- `userApiUpdateEmailEndpoint`