### PR TITLE
feat(core): allow typing of request errors with special support for J…

### DIFF
--- a/.changeset/funny-donkeys-happen.md
+++ b/.changeset/funny-donkeys-happen.md
@@ -1,0 +1,7 @@
+---
+"@drupal-kit/jsonapi": minor
+"@drupal-kit/types": minor
+"@drupal-kit/core": minor
+---
+
+Allow specifying a type for error responses with special support for JSON:API compliant errors.

--- a/packages/core/src/Drupalkit.ts
+++ b/packages/core/src/Drupalkit.ts
@@ -138,11 +138,11 @@ export class Drupalkit {
    * @param options - Request options.
    * @param optionOverrides - Optional overridden options. These options are merged correctly with the actual options and allow for user-specific overrides.
    */
-  public request<R>(
+  public request<R, E = unknown>(
     url: Url,
     options: RequestOptions,
     optionOverrides?: OverrideableRequestOptions,
-  ): Promise<Result<DrupalkitResponse<R, number>, DrupalkitError>> {
+  ): Promise<Result<DrupalkitResponse<R, number>, DrupalkitError<E>>> {
     // eslint-disable-next-line jsdoc/require-jsdoc
     const request = (options: RequestRequestOptions) => {
       return fetchWrapper<R>(options);

--- a/packages/core/src/DrupalkitError.ts
+++ b/packages/core/src/DrupalkitError.ts
@@ -1,4 +1,5 @@
 import * as DrupalkitTypes from "@drupal-kit/types";
+import { JsonApiError } from "@drupal-kit/types";
 
 import { RequestErrorOptions } from "./types.js";
 
@@ -6,10 +7,16 @@ import { RequestErrorOptions } from "./types.js";
 
 export type DrupalkitErrorOptions = RequestErrorOptions;
 
+type GenericJsonApiError = {
+  code: "drupalkit_error";
+  detail: string;
+  status: string;
+};
+
 /**
  * Custom error class to help with error handling.
  */
-export class DrupalkitError extends Error {
+export class DrupalkitError<T = unknown> extends Error {
   /**
    * Error name.
    */
@@ -29,6 +36,16 @@ export class DrupalkitError extends Error {
    * Response object if a response was received.
    */
   readonly response?: DrupalkitTypes.DrupalkitResponse<unknown>;
+
+  /**
+   * Array of JSON:API errors if the response contains them.
+   */
+  readonly errors: T[] | undefined;
+
+  /**
+   * The first JSON:API error if the response contains multiple errors.
+   */
+  readonly firstError: T | undefined;
 
   /**
    * Construct a new DrupalkitError.
@@ -56,6 +73,20 @@ export class DrupalkitError extends Error {
 
     if (options.response) {
       this.response = options.response;
+
+      // Parse JSON:API errors if the response has the correct content type
+      if (this.isJsonApiResponse()) {
+        const responseData = options.response.data as { errors?: T[] };
+        if (responseData.errors) {
+          this.errors = responseData.errors;
+          this.firstError = responseData.errors[0];
+        }
+      }
+      // @todo - Add better support for non-JSON:API responses.
+      else {
+        this.errors = [options.response.data as T];
+        this.firstError = options.response.data as T;
+      }
     }
 
     // redact request credentials without mutating original request options
@@ -71,4 +102,80 @@ export class DrupalkitError extends Error {
 
     this.request = requestCopy;
   }
+
+  /**
+   * Checks if the response contains JSON:API errors.
+   */
+  public isJsonApiError<
+    TM = T extends JsonApiError ? IntersectPick<T, keyof JsonApiError> : never,
+  >(): this is DrupalkitError<TM> & {
+    firstError: TM;
+    errors: TM[];
+  } {
+    return (
+      this.isJsonApiResponse() &&
+      Array.isArray(this.errors) &&
+      this.errors.length > 0
+    );
+  }
+
+  /**
+   * Gets a specific error by its error code.
+   *
+   * @param code - The error code to search for.
+   * @returns The first error matching the provided code, or undefined if not found.
+   */
+  public getErrorByCode<
+    C extends T extends { code: string } ? T["code"] : never,
+  >(code: C): Extract<T, { code: C }> | undefined {
+    return this.errors?.find((error) => {
+      if (error && typeof error === "object" && "code" in error) {
+        return error.code === code;
+      }
+
+      return false;
+    }) as Extract<T, { code: C }>;
+  }
+
+  /**
+   * Converts the error to a JSON:API compliant error object.
+   *
+   * If this is already a JSON:API error (has errors array), returns the first error.
+   * Otherwise returns a generic error object with the message and status code.
+   *
+   * @returns A JSON:API compliant error object.
+   */
+  public toJsonApiError(): T extends JsonApiError
+    ? IntersectPick<T, keyof JsonApiError> | GenericJsonApiError
+    : GenericJsonApiError {
+    if (this.isJsonApiError()) {
+      return this.firstError as T extends JsonApiError
+        ? T & GenericJsonApiError
+        : GenericJsonApiError;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return {
+      code: "drupalkit_error",
+      detail: this.message,
+      status: this.statusCode.toString(),
+    } as T extends JsonApiError ? T & GenericJsonApiError : GenericJsonApiError;
+  }
+
+  /**
+   * Checks if the response has the JSON:API content type.
+   */
+  private isJsonApiResponse(): boolean {
+    const contentType = Object.keys(this.response?.headers ?? {}).find(
+      (key) => key.toLowerCase() === "content-type",
+    );
+
+    return (
+      this.response?.headers?.[contentType ?? ""] === "application/vnd.api+json"
+    );
+  }
 }
+
+type IntersectPick<T, K extends keyof T> = {
+  [P in K & keyof T]: T[P];
+};

--- a/packages/core/tests/error.test-d.ts
+++ b/packages/core/tests/error.test-d.ts
@@ -1,0 +1,144 @@
+import { Drupalkit } from "@drupal-kit/core";
+
+const BASE_URL = "https://my-drupal.com";
+
+/**
+ * Test with no error type.
+ */
+async function testNoErrorTypeArgument() {
+  const drupalkit = new Drupalkit({
+    baseUrl: BASE_URL,
+  });
+
+  const result = await drupalkit.request<{ success: boolean }>(
+    "/demo-endpoint",
+    {
+      method: "GET",
+    },
+  );
+
+  const err = result.expectErr("must be error");
+
+  // @ts-expect-error firstError MUST NOT be definitively defined.
+  console.log(err.firstError.code);
+
+  // @ts-expect-error Code is `never`, due to no type argument.
+  err.getErrorByCode("some_code");
+
+  // Would never match in runtime.
+  if (err.isJsonApiError()) {
+    // @ts-expect-error firstError is of type never!
+    console.log(err.firstError.code);
+  }
+
+  const jsonApiError = err.toJsonApiError();
+
+  // Only the generic error is definitively defined.
+  if (jsonApiError.code === "drupalkit_error") {
+  }
+
+  // @ts-expect-error Ensure code is not just a `string`.
+  if (jsonApiError.code === "access_denied") {
+  }
+}
+
+/**
+ * Test with incompatible error type.
+ *
+ * Should behave as if no error type was provided, due to
+ * no properties are in common with the JSON:API error type.
+ */
+async function testNonCompatibleErrorType() {
+  const drupalkit = new Drupalkit({
+    baseUrl: BASE_URL,
+  });
+
+  const result = await drupalkit.request<
+    { success: boolean },
+    {
+      wrong_prop_one: "error-code";
+      wrong_title: "some title";
+    }
+  >("/demo-endpoint", {
+    method: "GET",
+  });
+
+  const err = result.expectErr("must be error");
+
+  // @ts-expect-error firstError MUST NOT be definitively defined.
+  console.log(err.firstError.code);
+
+  // @ts-expect-error Code is `never`, due to no type argument.
+  err.getErrorByCode("some_code");
+
+  // Would never match in runtime.
+  if (err.isJsonApiError()) {
+    // @ts-expect-error firstError is of type never!
+    console.log(err.firstError.code);
+  }
+
+  const jsonApiError = err.toJsonApiError();
+
+  // Only the generic error is definitively defined.
+  if (jsonApiError.code === "drupalkit_error") {
+  }
+
+  // @ts-expect-error Ensure code is not just a `string`.
+  if (jsonApiError.code === "access_denied") {
+  }
+}
+
+/**
+ * Test with semi-incompatible error type.
+ *
+ * Only the code is in common with the JSON:API error type,
+ * other properties are stripped.
+ */
+async function testSemiCompatibleErrorType() {
+  const drupalkit = new Drupalkit({
+    baseUrl: BASE_URL,
+  });
+
+  const result = await drupalkit.request<
+    { success: boolean },
+    {
+      code: "error-code";
+      wrong_title: "some title";
+    }
+  >("/demo-endpoint", {
+    method: "GET",
+  });
+
+  const err = result.expectErr("must be error");
+
+  // Error can be retrieved by code.
+  const errorByCode = err.getErrorByCode("error-code");
+  // The non compliant property is still accessible here.
+  console.log(errorByCode!.wrong_title);
+
+  // Incompatible properties are only stripped for the
+  // jsonapi related methods.
+
+  // Would never match in runtime.
+  if (err.isJsonApiError()) {
+    // firstError is defined here.
+    console.log(err.firstError.code);
+
+    // @todo - this should be an error, but type narrowing
+    // with the type guard in isJsonApiError is only creating
+    // a intersection type, not a narrowed type.
+    console.log(err.firstError.wrong_title);
+  }
+
+  const jsonApiError = err.toJsonApiError();
+
+  // Generic error is defined.
+  if (jsonApiError.code === "drupalkit_error") {
+  }
+
+  // Error code is defined.
+  if (jsonApiError.code === "error-code") {
+    // @ts-expect-error wrong_title is stripped.
+    console.log(jsonApiError.wrong_title);
+  }
+}

--- a/packages/jsonapi/tests/DrupalkitJsonApiError.test.ts
+++ b/packages/jsonapi/tests/DrupalkitJsonApiError.test.ts
@@ -28,7 +28,9 @@ test("Extract errors from JSON:API response", (t) => {
   const error = new DrupalkitError("test-error", 400, {
     request,
     response: {
-      headers: {},
+      headers: {
+        "Content-Type": "application/vnd.api+json",
+      },
       status: 422,
       data: JsonApiErrorResponse,
       url: "some-url",

--- a/packages/types/src/DrupalkitError.ts
+++ b/packages/types/src/DrupalkitError.ts
@@ -8,3 +8,14 @@ export type DrupalkitError = {
     message?: string;
   }>;
 };
+
+export type JsonApiError = {
+  code?: string;
+  title?: string;
+  status?: string;
+  detail?: string;
+  source?: {
+    pointer?: string;
+  };
+  meta?: Record<string, unknown>;
+};


### PR DESCRIPTION
Adds the ability to also specify the error type for `drupalkit.request()` as the second type parameter.

The `DrupalkitError` class has been updated to support a generic type argument for the contained error responses.

When the type argument is compatible with the JSON:API specification, just add a union type with available errors to the `drupalkit.request()` calls as the second type argument.

Errors can then be retrieved via `err.toJsonApiError()`. This function also makes sure that all returned errors match the specification, if the error response is not a JSON:API response, a generic JSON:API compatible error is returned instead.

To access a non JSON:API compliant error, just access the `err.firstError` property.

Fixes #101.