### PR TITLE
feat: triage open SDK issues

### DIFF
--- a/.changeset/open-issues-triage.md
+++ b/.changeset/open-issues-triage.md
@@ -1,0 +1,7 @@
+---
+"@drupal-kit/core": minor
+"@drupal-kit/jsonapi": minor
+"@drupal-kit/simple-oauth": minor
+---
+
+Add default request headers, dynamic auth providers, JSON:API pagination parameters, optional relationship type support, sanitized Drupal server errors, and camel-case OAuth grant payloads with PKCE code verifier support.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ Install additional plugins depending on your use-case.
 A core feature of Drupal Kit is it's hook system, thanks to [before-after-hook](https://github.com/gr2m/before-after-hook).
 This hook system makes it possible to register custom hooks before and after the target function is executed.
 
+Drupal Kit also supports instance-wide headers and dynamic auth data:
+
+```typescript
+import { Drupalkit } from "@drupal-kit/core";
+
+const drupalkit = new Drupalkit({
+  baseUrl: "https://example.com",
+  defaultHeaders: {
+    "X-App": "my-app",
+  },
+  auth: async () => `Bearer ${await getAccessToken()}`,
+});
+```
+
 ### `request` hook
 
 The `request` hook is used to register custom hooks before and after the `request` function is executed.
@@ -94,7 +108,9 @@ const EnhancedDrupalkit = Drupalkit.plugin(
 );
 
 // Create a Drupal Kit instance.
-const drupalkit = new EnhancedDrupalkit();
+const drupalkit = new EnhancedDrupalkit({
+  baseUrl: "https://example.com",
+});
 ```
 
 A plugin is just a function that takes the core `Drupalkit` and the `DrupalkitOptions` as arguments.
@@ -125,12 +141,22 @@ This plugin integrates with the built-in `jsonapi` drupal core module.
 - [x] `DELETE` JSON:API resource
 - [x] Localization
 - [x] Query Parameters
+- [x] Pagination
 
 **Typescript:**
 
 The JSON:API resources are strongly typed via the `JsonApiResources` interface.
 This interface MUST be augmented in your code in order for TypeScript to infer the
-correct types for the `Drupalkit.jsonapi.resource()` method.
+correct types for the `drupalkit.jsonApi.resource()` method.
+
+```typescript
+await drupalkit.jsonApi.resource("node--article", "readMany", {
+  pagination: {
+    limit: 10,
+    offset: 20,
+  },
+});
+```
 
 ### Simple OAuth
 
@@ -140,8 +166,22 @@ This plugin integrates with the [`simple_oauth`](https://www.drupal.org/project/
 
 - [x] `/oauth/token` endpoint
 - [x] `/oauth/userinfo` endpoint
+- [x] PKCE `code_verifier` support for authorization code grants
 - [ ] `/oauth/authorize` endpoint
 - [ ] `/oauth/jwks` endpoint
+
+OAuth grant payloads accept camel-case properties and are serialized to the
+form field names expected by Drupal:
+
+```typescript
+await drupalkit.simpleOauth.requestToken("authorization_code", {
+  clientId: "client-id",
+  clientSecret: "client-secret",
+  code: "auth-code",
+  redirectUri: "https://example.com/callback",
+  codeVerifier: "pkce-verifier",
+});
+```
 
 ### Simple OAuth Auth Code
 

--- a/packages/core/src/Drupalkit.ts
+++ b/packages/core/src/Drupalkit.ts
@@ -7,6 +7,7 @@ import {
   Log,
   OverrideableRequestOptions,
   RequestOptions,
+  RequestHeaders,
   RequestRequestOptions,
   Url,
 } from "@drupal-kit/types";
@@ -14,6 +15,7 @@ import {
 import { DrupalkitError } from "./DrupalkitError.js";
 import fetchWrapper from "./fetch-wrapper.js";
 import {
+  AuthHeaderValue,
   Constructor,
   DrupalkitOptions,
   DrupalkitPlugin,
@@ -40,10 +42,11 @@ export class Drupalkit {
   readonly availableLocales: string[] = [];
   readonly defaultLocale?: string;
   readonly agent: string;
+  readonly defaultHeaders: RequestHeaders;
   readonly log: Log;
   readonly hook: HookCollection<Hooks>;
   private locale?: string;
-  private auth?: string;
+  private auth?: AuthHeaderValue;
 
   /**
    * Attach a plugin (or many) to your Drupalkit instance.
@@ -98,6 +101,8 @@ export class Drupalkit {
     this.hook = hook;
     this.baseUrl = trimSlashesFromSegment(options.baseUrl);
     this.agent = `drupal-kit/${VERSION}`;
+    this.defaultHeaders = options.defaultHeaders ?? {};
+    this.auth = options.auth;
 
     if (options.locale) {
       this.locale = options.locale;
@@ -138,17 +143,20 @@ export class Drupalkit {
    * @param options - Request options.
    * @param optionOverrides - Optional overridden options. These options are merged correctly with the actual options and allow for user-specific overrides.
    */
-  public request<R, E = unknown>(
+  public async request<TResponse, TError = unknown>(
     url: Url,
     options: RequestOptions,
     optionOverrides?: OverrideableRequestOptions,
-  ): Promise<Result<DrupalkitResponse<R, number>, DrupalkitError<E>>> {
+  ): Promise<
+    Result<DrupalkitResponse<TResponse, number>, DrupalkitError<TError>>
+  > {
     // eslint-disable-next-line jsdoc/require-jsdoc
     const request = (options: RequestRequestOptions) => {
-      return fetchWrapper<R>(options);
+      return fetchWrapper<TResponse>(options);
     };
 
     const headers = {
+      ...this.defaultHeaders,
       ...options.headers,
       "user-agent": this.agent,
     };
@@ -161,7 +169,10 @@ export class Drupalkit {
     if (options.unauthenticated || optionOverrides?.unauthenticated) {
       delete headers.authorization;
     } else if (this.auth) {
-      headers.authorization = this.auth;
+      const auth = await this.resolveAuth();
+      if (auth) {
+        headers.authorization = auth;
+      }
     }
 
     const requestOptions = {
@@ -176,7 +187,9 @@ export class Drupalkit {
     };
 
     const p = this.hook("request", request, requestOptions)
-      .then((response) => Result.Ok(response as DrupalkitResponse<R, number>))
+      .then((response) =>
+        Result.Ok(response as DrupalkitResponse<TResponse, number>),
+      )
       .catch((error) => {
         if (error instanceof DrupalkitError) return Result.Err(error);
 
@@ -195,7 +208,7 @@ export class Drupalkit {
    *
    * @param auth - The authorization header value.
    */
-  public setAuth(auth: string) {
+  public setAuth(auth: AuthHeaderValue) {
     this.auth = auth;
   }
 
@@ -213,6 +226,13 @@ export class Drupalkit {
    */
   public unsetAuth() {
     this.auth = undefined;
+  }
+
+  /**
+   * Resolve the current authorization header value.
+   */
+  private async resolveAuth() {
+    return typeof this.auth === "function" ? await this.auth() : this.auth;
   }
 
   /**

--- a/packages/core/src/fetch-wrapper.ts
+++ b/packages/core/src/fetch-wrapper.ts
@@ -10,7 +10,7 @@ import { DrupalkitError, UNKNOWN_ERROR_PREFIX } from "./DrupalkitError.js";
  *
  * @param requestOptions - Options for the request.
  */
-export default function fetchWrapper<R>(
+export default function fetchWrapper<TResponse>(
   requestOptions: RequestRequestOptions & {
     redirect?: "error" | "follow" | "manual";
     fetch?: Fetch;
@@ -56,7 +56,10 @@ export default function fetchWrapper<R>(
       }
 
       if (status >= 400) {
-        const data = await getResponseData(response);
+        const data = sanitizeServerErrorData(
+          await getResponseData(response),
+          status,
+        );
 
         const error = new DrupalkitError(toErrorMessage(data), status, {
           response: {
@@ -78,7 +81,7 @@ export default function fetchWrapper<R>(
         status,
         url,
         headers,
-        data: data as R,
+        data: data as TResponse,
       };
     })
     .catch((error) => {
@@ -133,4 +136,41 @@ function toErrorMessage(data: unknown): string {
 
   // istanbul ignore next - just in case
   return `${UNKNOWN_ERROR_PREFIX} ${JSON.stringify(data)}`;
+}
+
+/**
+ * Replace detailed server errors with a generic message.
+ *
+ * @param data - The response data.
+ * @param status - The HTTP status code.
+ */
+function sanitizeServerErrorData(data: unknown, status: number) {
+  if (status < 500 || !hasServerErrorDetails(data)) {
+    return data;
+  }
+
+  return "The Drupal server returned an internal error.";
+}
+
+/**
+ * Check if response data appears to contain a server trace.
+ *
+ * @param data - The response data.
+ */
+function hasServerErrorDetails(data: unknown): boolean {
+  if (typeof data === "string") {
+    return /stack trace|traceback|^\s*#\d+\s|\n\s*at\s+\S+/im.test(data);
+  }
+
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  return Object.entries(data).some(([key, value]) => {
+    if (/trace|backtrace|exception|file|line/i.test(key)) {
+      return true;
+    }
+
+    return hasServerErrorDetails(value);
+  });
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 import { ParsedQs } from "qs";
 import * as DrupalkitTypes from "@drupal-kit/types";
-import { Fetch } from "@drupal-kit/types";
+import { Fetch, RequestHeaders } from "@drupal-kit/types";
 
 import { DrupalkitError } from "./DrupalkitError.js";
 import { Drupalkit } from "./index.js";
@@ -10,6 +10,8 @@ export interface DrupalkitOptions {
   locale?: string;
   availableLocales?: string[];
   defaultLocale?: string;
+  defaultHeaders?: RequestHeaders;
+  auth?: AuthHeaderValue;
   log?: {
     debug: (message: string) => unknown;
     info: (message: string) => unknown;
@@ -21,6 +23,11 @@ export interface DrupalkitOptions {
 }
 
 export type Query = ParsedQs | object;
+export type AuthHeaderValue =
+  | string
+  | null
+  | undefined
+  | (() => string | null | undefined | Promise<string | null | undefined>);
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -40,10 +47,10 @@ export type ReturnTypeOf<T extends AnyFunction | AnyFunction[]> =
  * @author https://stackoverflow.com/users/2887218/jcalz
  * @see https://stackoverflow.com/a/50375286/10325032
  */
-export type UnionToIntersection<Union> = (
-  Union extends any ? (argument: Union) => void : never
-) extends (argument: infer Intersection) => void // tslint:disable-line: no-unused
-  ? Intersection
+export type UnionToIntersection<TUnion> = (
+  TUnion extends any ? (argument: TUnion) => void : never
+) extends (argument: infer TIntersection) => void // tslint:disable-line: no-unused
+  ? TIntersection
   : never;
 
 type AnyFunction = (...args: any) => any;

--- a/packages/core/tests/requests.test.ts
+++ b/packages/core/tests/requests.test.ts
@@ -16,6 +16,12 @@ const server = setupServer(
     return HttpResponse.json(DemoEndpointResponse);
   }),
   http.get("*/not-found", () => HttpResponse.text("", { status: 404 })),
+  http.get("*/server-error", () =>
+    HttpResponse.text(
+      "Error: Database credentials leaked\n    at connect (/app/index.php:10:1)",
+      { status: 500 },
+    ),
+  ),
   http.get("*/network-error", () => HttpResponse.error()),
 );
 
@@ -269,6 +275,62 @@ test.serial("Add auth header if present", async (t) => {
   });
 });
 
+test.serial("Resolve auth header before each request", async (t) => {
+  t.plan(2);
+  let token = "Bearer first";
+
+  server.use(
+    http.get("*/demo-endpoint", ({ request }) => {
+      t.is(request.headers.get("authorization"), token);
+
+      return HttpResponse.text();
+    }),
+  );
+
+  const drupalkit = new Drupalkit({
+    baseUrl: BASE_URL,
+    auth: () => token,
+  });
+
+  await drupalkit.request("/demo-endpoint", {
+    method: "GET",
+  });
+
+  token = "Bearer second";
+
+  await drupalkit.request("/demo-endpoint", {
+    method: "GET",
+  });
+});
+
+test.serial("Apply default request headers", async (t) => {
+  t.plan(2);
+
+  server.use(
+    http.get("*/demo-endpoint", ({ request }) => {
+      t.is(request.headers.get("X-Default"), "default");
+      t.is(request.headers.get("X-Override"), "request");
+
+      return HttpResponse.text();
+    }),
+  );
+
+  const drupalkit = new Drupalkit({
+    baseUrl: BASE_URL,
+    defaultHeaders: {
+      "X-Default": "default",
+      "X-Override": "default",
+    },
+  });
+
+  await drupalkit.request("/demo-endpoint", {
+    method: "GET",
+    headers: {
+      "X-Override": "request",
+    },
+  });
+});
+
 test.serial("Handle network errors", async (t) => {
   const drupalkit = new Drupalkit({
     baseUrl: BASE_URL,
@@ -283,6 +345,21 @@ test.serial("Handle network errors", async (t) => {
 
   t.assert(error instanceof DrupalkitError);
   t.is(error.response, undefined);
+});
+
+test.serial("Sanitize Drupal server error details", async (t) => {
+  const drupalkit = new Drupalkit({
+    baseUrl: BASE_URL,
+  });
+
+  const result = await drupalkit.request("/server-error", {
+    method: "GET",
+  });
+
+  const error = result.expectErr("Must be error");
+
+  t.is(error.message, "The Drupal server returned an internal error.");
+  t.is(error.response?.data, "The Drupal server returned an internal error.");
 });
 
 test.serial("Allow options overrides", async (t) => {

--- a/packages/jsonapi/src/DrupalkitJsonApi.ts
+++ b/packages/jsonapi/src/DrupalkitJsonApi.ts
@@ -13,6 +13,7 @@ import {
   FileRelationshipKeys,
   JsonApiIndex,
   JsonApiResource,
+  JsonApiResourceOperationResult,
   JsonApiResources,
   MenuLinkContentResource,
   ReadManyParameters,
@@ -22,6 +23,7 @@ import {
   ToParameters,
   UpdateParameters,
   ValidOperation,
+  WithPaginationLinks,
 } from "./resources.js";
 import {
   isJsonApiRequest,
@@ -113,8 +115,9 @@ export const DrupalkitJsonApi = (
    * @returns A result object containing the resource object or an error.
    */
   const getResource = async <
-    R extends JsonApiResource,
-    TResourceObject extends DeriveResourceObject<R> = DeriveResourceObject<R>,
+    TResource extends JsonApiResource,
+    TResourceObject extends
+      DeriveResourceObject<TResource> = DeriveResourceObject<TResource>,
   >(
     type: ResourceType,
     parameters: ReadSingleParameters,
@@ -128,7 +131,7 @@ export const DrupalkitJsonApi = (
 
     const url = buildJsonApiUrl(path, {
       localeOverride: requestOptions?.locale,
-      query: parameters.queryParams?.getQueryObject(),
+      query: buildReadQuery(parameters),
     });
 
     const result = await drupalkit.request<Response<TResourceObject>>(
@@ -156,8 +159,10 @@ export const DrupalkitJsonApi = (
    * @param data - The resource response to simplify.
    */
   const simplifyResourceResponse = <
-    R extends JsonApiResource,
-    TResourceObject extends DeriveResourceObject<R> | DeriveResourceObject<R>[],
+    TResource extends JsonApiResource,
+    TResourceObject extends
+      | DeriveResourceObject<TResource>
+      | DeriveResourceObject<TResource>[],
     TSimpleResource extends SimpleFromResourceObject<TResourceObject>,
   >(
     data: Response<TResourceObject>,
@@ -176,8 +181,9 @@ export const DrupalkitJsonApi = (
    * @returns A result object containing the resource object or an error.
    */
   const getResourceCollection = async <
-    R extends JsonApiResource,
-    TResourceObject extends DeriveResourceObject<R> = DeriveResourceObject<R>,
+    TResource extends JsonApiResource,
+    TResourceObject extends
+      DeriveResourceObject<TResource> = DeriveResourceObject<TResource>,
   >(
     type: ResourceType,
     parameters: ReadManyParameters,
@@ -185,12 +191,17 @@ export const DrupalkitJsonApi = (
     options?: {
       path?: string;
     },
-  ): Promise<Result<Response<TResourceObject[]>, DrupalkitJsonApiError>> => {
+  ): Promise<
+    Result<
+      WithPaginationLinks<Response<TResourceObject[]>>,
+      DrupalkitJsonApiError
+    >
+  > => {
     const path = options?.path ?? type.replace("--", "/");
 
     const url = buildJsonApiUrl(path, {
       localeOverride: requestOptions?.locale,
-      query: parameters.queryParams?.getQueryObject(),
+      query: buildReadQuery(parameters),
     });
 
     const result = await drupalkit.request<Response<TResourceObject[]>>(
@@ -220,11 +231,12 @@ export const DrupalkitJsonApi = (
    * @returns A result object containing the resource object or an error.
    */
   const createResource = async <
-    R extends JsonApiResource,
-    TResourceObject extends DeriveResourceObject<R> = DeriveResourceObject<R>,
+    TResource extends JsonApiResource,
+    TResourceObject extends
+      DeriveResourceObject<TResource> = DeriveResourceObject<TResource>,
   >(
     type: ResourceType,
-    parameters: CreateParameters<R>,
+    parameters: CreateParameters<TResource>,
     requestOptions?: OverrideableRequestOptions,
     options?: {
       path?: string;
@@ -271,11 +283,12 @@ export const DrupalkitJsonApi = (
    * @returns A result object containing the resource object or an error.
    */
   const updateResource = async <
-    R extends JsonApiResource,
-    TResourceObject extends DeriveResourceObject<R> = DeriveResourceObject<R>,
+    TResource extends JsonApiResource,
+    TResourceObject extends
+      DeriveResourceObject<TResource> = DeriveResourceObject<TResource>,
   >(
     type: ResourceType,
-    parameters: UpdateParameters<R>,
+    parameters: UpdateParameters<TResource>,
     requestOptions?: OverrideableRequestOptions,
     options?: {
       path?: string;
@@ -375,6 +388,15 @@ export const DrupalkitJsonApi = (
     });
   };
 
+  const buildReadQuery = (
+    parameters: ReadSingleParameters | ReadManyParameters,
+  ) => {
+    return {
+      ...parameters.queryParams?.getQueryObject(),
+      ...(parameters.pagination ? { page: parameters.pagination } : {}),
+    };
+  };
+
   /**
    * Upload a file to an entity's file relationship field.
    *
@@ -386,12 +408,12 @@ export const DrupalkitJsonApi = (
    * @param requestOptions - Optional request options.
    */
   const uploadFile = async <
-    Type extends keyof JsonApiResources,
-    TField extends FileRelationshipKeys<Type>,
+    TType extends keyof JsonApiResources,
+    TField extends FileRelationshipKeys<TType>,
     TFileResource extends
-      JsonApiResources[Type]["resource"]["relationships"][TField],
+      JsonApiResources[TType]["resource"]["relationships"][TField],
   >(
-    type: Type,
+    type: TType,
     uuid: string,
     fieldName: TField,
     file: File | Blob,
@@ -473,70 +495,56 @@ export const DrupalkitJsonApi = (
       getMenuItems,
       uploadFile,
       async resource<
-        Type extends keyof JsonApiResources,
-        Resource extends JsonApiResources[Type]["resource"],
-        Operation extends JsonApiResources[Type]["operations"],
-        Params extends ToParameters<Operation, Resource>,
-        Return extends Record<
-          Operation,
-          "readSingle" extends Operation
-            ? Awaited<ReturnType<typeof getResource<Resource>>>
-            : "readMany" extends Operation
-              ? Awaited<ReturnType<typeof getResourceCollection<Resource>>>
-              : "create" extends Operation
-                ? Awaited<ReturnType<typeof createResource<Resource>>>
-                : "update" extends Operation
-                  ? Awaited<ReturnType<typeof updateResource<Resource>>>
-                  : "delete" extends Operation
-                    ? Awaited<ReturnType<typeof deleteResource>>
-                    : Result<never, Error>
-        >,
+        TType extends keyof JsonApiResources,
+        TResource extends JsonApiResources[TType]["resource"],
+        TOperation extends JsonApiResources[TType]["operations"],
+        TParams extends ToParameters<TOperation, TResource>,
       >(
-        type: Type,
-        operation: Operation,
-        parameters: Params,
+        type: TType,
+        operation: TOperation,
+        parameters: TParams,
         requestOptions?: OverrideableRequestOptions,
-      ): Promise<Return[Operation]> {
+      ): Promise<JsonApiResourceOperationResult<TResource, TOperation>> {
         switch (operation as ValidOperation) {
           case "readSingle":
             return (await getResource(
               type,
               parameters as ReadSingleParameters,
               requestOptions,
-            )) as Return[Operation];
+            )) as JsonApiResourceOperationResult<TResource, TOperation>;
 
           case "readMany":
             return (await getResourceCollection(
               type,
               parameters as ReadManyParameters,
               requestOptions,
-            )) as Return[Operation];
+            )) as JsonApiResourceOperationResult<TResource, TOperation>;
 
           case "create":
             return (await createResource(
               type,
-              parameters as CreateParameters<Resource>,
+              parameters as CreateParameters<TResource>,
               requestOptions,
-            )) as Return[Operation];
+            )) as JsonApiResourceOperationResult<TResource, TOperation>;
 
           case "update":
             return (await updateResource(
               type,
-              parameters as UpdateParameters<Resource>,
+              parameters as UpdateParameters<TResource>,
               requestOptions,
-            )) as Return[Operation];
+            )) as JsonApiResourceOperationResult<TResource, TOperation>;
 
           case "delete":
             return (await deleteResource(
               type,
               parameters as DeleteParameters,
               requestOptions,
-            )) as Return[Operation];
+            )) as JsonApiResourceOperationResult<TResource, TOperation>;
 
           default:
             return Result.Err(
               new Error(`Unknown operation "${operation}"`),
-            ) as Return[Operation];
+            ) as JsonApiResourceOperationResult<TResource, TOperation>;
         }
       },
     },

--- a/packages/jsonapi/src/resources.ts
+++ b/packages/jsonapi/src/resources.ts
@@ -131,13 +131,41 @@ export interface RelationshipLinkage<T extends string> {
  */
 
 type ExtractArrayElementType<T> = T extends Array<infer U> ? U : never;
+type DeriveDepth = 0 | 1 | 2 | 3 | 4 | 5;
+type PreviousDepth = {
+  0: 0;
+  1: 0;
+  2: 1;
+  3: 2;
+  4: 3;
+  5: 4;
+};
 
-type DeriveSimpleJsonApiResourceUnion<T> = T extends infer U extends
-  JsonApiResource
-  ? DeriveSimpleJsonApiResource<U>
+type DeriveSimpleJsonApiResourceUnion<
+  TResource,
+  TDepth extends DeriveDepth,
+> = TResource extends infer U extends JsonApiResource
+  ? DeriveSimpleJsonApiResource<U, PreviousDepth[TDepth]>
   : never;
 
-export type DeriveSimpleJsonApiResource<TResource extends JsonApiResource> = {
+type DeriveSimpleJsonApiResourceRelationship<
+  TRelationship,
+  TDepth extends DeriveDepth,
+> = TDepth extends 0
+  ? never
+  : NonNullable<TRelationship> extends JsonApiResource
+    ? DeriveSimpleJsonApiResourceUnion<NonNullable<TRelationship>, TDepth>
+    : NonNullable<TRelationship> extends JsonApiResource[]
+      ? DeriveSimpleJsonApiResourceUnion<
+          ExtractArrayElementType<NonNullable<TRelationship>>,
+          TDepth
+        >[]
+      : never;
+
+export type DeriveSimpleJsonApiResource<
+  TResource extends JsonApiResource,
+  TDepth extends DeriveDepth = 5,
+> = {
   id: TResource["id"];
   type: TResource["type"];
   resourceIdObjMeta: {
@@ -156,12 +184,14 @@ export type DeriveSimpleJsonApiResource<TResource extends JsonApiResource> = {
     : never;
 } & {
   [key in keyof TResource["relationships"]]: TResource["relationships"][key] extends JsonApiResource
-    ? DeriveSimpleJsonApiResourceUnion<TResource["relationships"][key]>
-    : TResource["relationships"][key] extends JsonApiResource[]
-      ? DeriveSimpleJsonApiResourceUnion<
-          ExtractArrayElementType<TResource["relationships"][key]>
-        >[]
-      : never;
+    ? DeriveSimpleJsonApiResourceRelationship<
+        TResource["relationships"][key],
+        TDepth
+      >
+    : DeriveSimpleJsonApiResourceRelationship<
+        TResource["relationships"][key],
+        TDepth
+      >;
 };
 
 /**
@@ -169,13 +199,37 @@ export type DeriveSimpleJsonApiResource<TResource extends JsonApiResource> = {
  * object from a standard json api resource object.
  */
 
-type DeriveResourceObjectUnion<T> = T extends infer U extends JsonApiResource
-  ? DeriveResourceObject<U>
+type DeriveResourceObjectUnion<
+  TResource,
+  TDepth extends DeriveDepth,
+> = TResource extends infer U extends JsonApiResource
+  ? DeriveResourceObject<U, PreviousDepth[TDepth]>
   : never;
 
-export type DeriveResourceObject<TResource extends JsonApiResource> = {
-  type: TResource["type"];
+type DeriveResourceObjectRelationship<
+  TRelationship,
+  TDepth extends DeriveDepth,
+> = TDepth extends 0
+  ? never
+  : NonNullable<TRelationship> extends JsonApiResource
+    ? Relationship<
+        DeriveResourceObjectUnion<NonNullable<TRelationship>, TDepth>
+      >
+    : NonNullable<TRelationship> extends JsonApiResource[]
+      ? Relationship<
+          DeriveResourceObjectUnion<
+            ExtractArrayElementType<NonNullable<TRelationship>>,
+            TDepth
+          >[]
+        >
+      : never;
+
+export type DeriveResourceObject<
+  TResource extends JsonApiResource,
+  TDepth extends DeriveDepth = 5,
+> = {
   id: TResource["id"];
+  type: TResource["type"];
   attributes: {
     [key in keyof TResource["attributes"]]: TResource["attributes"][key] extends Attributes[0]
       ? TResource["attributes"][key]
@@ -192,23 +246,38 @@ export type DeriveResourceObject<TResource extends JsonApiResource> = {
       : never;
   };
   relationships: {
-    [key in keyof TResource["relationships"]]: TResource["relationships"][key] extends JsonApiResource
-      ? Relationship<DeriveResourceObject<TResource["relationships"][key]>>
-      : TResource["relationships"][key] extends JsonApiResource[]
-        ? Relationship<
-            DeriveResourceObjectUnion<
-              ExtractArrayElementType<TResource["relationships"][key]>
-            >[]
-          >
-        : never;
+    [key in keyof TResource["relationships"]]: DeriveResourceObjectRelationship<
+      TResource["relationships"][key],
+      TDepth
+    >;
   };
 };
 
-type ResourceRelationshipLinkage<T> = T extends JsonApiResource
-  ? RelationshipLinkage<T["type"]>
-  : T extends JsonApiResource[]
-    ? RelationshipLinkage<ExtractArrayElementType<T>["type"]>[]
-    : never;
+type ResourceRelationshipLinkage<TRelationship> =
+  NonNullable<TRelationship> extends JsonApiResource
+    ? RelationshipLinkage<NonNullable<TRelationship>["type"]>
+    : NonNullable<TRelationship> extends JsonApiResource[]
+      ? RelationshipLinkage<
+          ExtractArrayElementType<NonNullable<TRelationship>>["type"]
+        >[]
+      : never;
+
+export type JsonApiPagination = {
+  limit?: number;
+  offset?: number;
+};
+
+export type JsonApiPaginationLinks = {
+  first?: Link | null;
+  prev?: Link | null;
+  next?: Link | null;
+  last?: Link | null;
+};
+
+export type WithPaginationLinks<TResponse extends { links?: unknown }> =
+  TResponse & {
+    links?: TResponse["links"] & JsonApiPaginationLinks;
+  };
 
 /**
  * Creates a simple json api resource from a resource object.
@@ -224,13 +293,13 @@ export type SimpleFromResourceObject<T> =
 /**
  * Extract the update payload type from a resource object.
  */
-type ResourceCreateUpdatePayload<R extends JsonApiResource> = object & {
-  id?: R["id"];
-  type?: R["type"];
-  attributes?: Partial<R["attributes"]>;
+type ResourceCreateUpdatePayload<TResource extends JsonApiResource> = object & {
+  id?: TResource["id"];
+  type?: TResource["type"];
+  attributes?: Partial<TResource["attributes"]>;
   relationships?: Partial<{
-    [key in keyof R["relationships"]]: {
-      data: ResourceRelationshipLinkage<R["relationships"][key]>;
+    [key in keyof TResource["relationships"]]: {
+      data: ResourceRelationshipLinkage<TResource["relationships"][key]>;
     } | null;
   }>;
 };
@@ -252,6 +321,27 @@ export type ResourceResult<
   DrupalkitJsonApiError
 >;
 
+export type JsonApiResourceOperationResult<
+  TResource extends JsonApiResource,
+  TOperation,
+> = TOperation extends "readSingle"
+  ? Result<Response<DeriveResourceObject<TResource>>, DrupalkitJsonApiError>
+  : TOperation extends "readMany"
+    ? Result<
+        WithPaginationLinks<Response<DeriveResourceObject<TResource>[]>>,
+        DrupalkitJsonApiError
+      >
+    : TOperation extends "create"
+      ? Result<Response<DeriveResourceObject<TResource>>, DrupalkitJsonApiError>
+      : TOperation extends "update"
+        ? Result<
+            Response<DeriveResourceObject<TResource>>,
+            DrupalkitJsonApiError
+          >
+        : TOperation extends "delete"
+          ? Result<true, DrupalkitJsonApiError>
+          : Result<never, DrupalkitJsonApiError>;
+
 /**
  * Remove index signature from T.
  *
@@ -271,6 +361,7 @@ export type RemoveIndex<T> = {
 
 type ReadParameters = {
   queryParams?: DrupalJsonApiParamsInterface;
+  pagination?: JsonApiPagination;
 };
 
 export type ReadSingleParameters = ReadParameters & {
@@ -279,13 +370,13 @@ export type ReadSingleParameters = ReadParameters & {
 
 export type ReadManyParameters = ReadParameters;
 
-export type CreateParameters<Resource extends JsonApiResource> = {
-  payload: ResourceCreateUpdatePayload<Resource>;
+export type CreateParameters<TResource extends JsonApiResource> = {
+  payload: ResourceCreateUpdatePayload<TResource>;
 };
 
-export type UpdateParameters<Resource extends JsonApiResource> = {
+export type UpdateParameters<TResource extends JsonApiResource> = {
   uuid: string;
-  payload: ResourceCreateUpdatePayload<Resource>;
+  payload: ResourceCreateUpdatePayload<TResource>;
 };
 
 export type DeleteParameters = {
@@ -296,17 +387,17 @@ export type DeleteParameters = {
  * Infer correct parameters by operation and resource type.
  */
 export type ToParameters<
-  Operation,
-  Resource extends JsonApiResource,
-> = "readSingle" extends Operation
+  TOperation,
+  TResource extends JsonApiResource,
+> = "readSingle" extends TOperation
   ? ReadSingleParameters
-  : "readMany" extends Operation
+  : "readMany" extends TOperation
     ? ReadManyParameters
-    : "create" extends Operation
-      ? CreateParameters<Resource>
-      : "update" extends Operation
-        ? UpdateParameters<Resource>
-        : "delete" extends Operation
+    : "create" extends TOperation
+      ? CreateParameters<TResource>
+      : "update" extends TOperation
+        ? UpdateParameters<TResource>
+        : "delete" extends TOperation
           ? DeleteParameters
           : never;
 

--- a/packages/jsonapi/tests/resources.test-d.ts
+++ b/packages/jsonapi/tests/resources.test-d.ts
@@ -163,6 +163,9 @@ async function testSimplifiedResourceObject() {
   const simplifiedRes = drupalkit.jsonApi.simplifyResourceResponse(res);
 
   expectType<DeriveSimpleJsonApiResource<NodeArticleResource>>(simplifiedRes);
+  expectType<DeriveSimpleJsonApiResource<FileResource> | undefined>(
+    simplifiedRes.field_teaser_image,
+  );
 
   // Test read many.
   const resMany = (
@@ -174,6 +177,17 @@ async function testSimplifiedResourceObject() {
   expectType<DeriveSimpleJsonApiResource<NodeArticleResource>[]>(
     simplifiedResMany,
   );
+}
+
+async function testPaginationParameters() {
+  const drupalkit = createDrupalkit();
+
+  await drupalkit.jsonApi.resource("node--article", "readMany", {
+    pagination: {
+      limit: 10,
+      offset: 20,
+    },
+  });
 }
 
 async function testDiscriminatedUnionRelationType() {

--- a/packages/jsonapi/tests/resources.test.ts
+++ b/packages/jsonapi/tests/resources.test.ts
@@ -374,6 +374,34 @@ test.serial("Get many resources", async (t) => {
   t.snapshot(res);
 });
 
+test.serial("Get many resources with pagination", async (t) => {
+  t.plan(2);
+  const drupalkit = createDrupalkit();
+
+  drupalkit.hook.before("request", (options) => {
+    const url = new URL(options.url);
+    t.is(url.searchParams.get("page[limit]"), "3");
+    t.is(url.searchParams.get("page[offset]"), "6");
+  });
+
+  server.use(
+    http.get("*/jsonapi/node/article", () => {
+      return HttpResponse.json(JsonApiArticleCollection, {
+        headers: {
+          "Content-Type": "application/vnd.api+json",
+        },
+      });
+    }),
+  );
+
+  await drupalkit.jsonApi.resource("node--article", "readMany", {
+    pagination: {
+      limit: 3,
+      offset: 6,
+    },
+  });
+});
+
 test.serial("Get many resources with custom request options", async (t) => {
   t.plan(3);
 

--- a/packages/jsonapi/tests/types.ts
+++ b/packages/jsonapi/tests/types.ts
@@ -33,6 +33,7 @@ export interface NodeArticleResource extends JsonApiResource {
   };
   relationships: {
     uid: UserResource;
+    field_teaser_image?: FileResource;
   };
 }
 

--- a/packages/simple-oauth-auth-code/src/DrupalkitSimpleOauthAuthCode.ts
+++ b/packages/simple-oauth-auth-code/src/DrupalkitSimpleOauthAuthCode.ts
@@ -19,7 +19,7 @@ declare module "@drupal-kit/core" {
  * @param drupalkit - The Drupalkit instance.
  * @param drupalkitOptions - The options for the Drupalkit instance.
  */
-export const DrupalkitSimpleOauthAuthCode = <Operation extends string>(
+export const DrupalkitSimpleOauthAuthCode = <TOperation extends string>(
   drupalkit: Drupalkit,
   drupalkitOptions: DrupalkitOptions,
 ) => {
@@ -37,7 +37,7 @@ export const DrupalkitSimpleOauthAuthCode = <Operation extends string>(
    * @param requestOptions - Optional request options.
    */
   const requestAuthCode = async (
-    operation: Operation,
+    operation: TOperation,
     email: string,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<AuthCodeResponse, DrupalkitError>> => {

--- a/packages/simple-oauth/src/DrupalkitSimpleOauth.ts
+++ b/packages/simple-oauth/src/DrupalkitSimpleOauth.ts
@@ -34,6 +34,45 @@ export const DrupalkitSimpleOauth = (
   const oauthUserInfoEndpoint =
     drupalkitOptions.oauthUserInfoEndpoint ?? "/oauth/userinfo";
 
+  const grantPayloadFields = {
+    authorization_code: {
+      clientId: "client_id",
+      client_id: "client_id",
+      clientSecret: "client_secret",
+      client_secret: "client_secret",
+      code: "code",
+      redirectUri: "redirect_uri",
+      redirect_uri: "redirect_uri",
+      codeVerifier: "code_verifier",
+      code_verifier: "code_verifier",
+    },
+    client_credentials: {
+      clientId: "client_id",
+      client_id: "client_id",
+      clientSecret: "client_secret",
+      client_secret: "client_secret",
+      scope: "scope",
+    },
+    refresh_token: {
+      clientId: "client_id",
+      client_id: "client_id",
+      clientSecret: "client_secret",
+      client_secret: "client_secret",
+      refreshToken: "refresh_token",
+      refresh_token: "refresh_token",
+      scope: "scope",
+    },
+    password: {
+      clientId: "client_id",
+      client_id: "client_id",
+      clientSecret: "client_secret",
+      client_secret: "client_secret",
+      username: "username",
+      password: "password",
+      scope: "scope",
+    },
+  } satisfies Record<keyof SimpleOauthGrantTypes, Record<string, string>>;
+
   /**
    * Request a access token via given grant.
    *
@@ -42,19 +81,18 @@ export const DrupalkitSimpleOauth = (
    * @param requestOptions - Optional request options.
    */
   const requestToken = async <
-    GrantType extends keyof SimpleOauthGrantTypes,
-    Grant extends SimpleOauthGrantTypes[GrantType],
+    TGrantType extends keyof SimpleOauthGrantTypes,
+    TGrant extends SimpleOauthGrantTypes[TGrantType],
   >(
-    grantType: GrantType,
-    grant: Grant,
+    grantType: TGrantType,
+    grant: TGrant,
     requestOptions?: OverrideableRequestOptions,
   ): Promise<Result<SimpleOauthTokenResponse, DrupalkitSimpleOauthError>> => {
     const url = drupalkit.buildUrl(oauthTokenEndpoint);
 
-    const body = new URLSearchParams();
-    body.append("grant_type", grantType);
-    for (const [key, value] of Object.entries(grant)) {
-      body.append(key, value);
+    const body = buildTokenRequestBody(grantType, grant);
+    if (body instanceof DrupalkitSimpleOauthError) {
+      return Result.Err(body);
     }
 
     const result = await drupalkit.request<SimpleOauthTokenResponse>(
@@ -77,6 +115,54 @@ export const DrupalkitSimpleOauth = (
     }
 
     return Result.Ok(result.val.data);
+  };
+
+  const buildTokenRequestBody = <
+    TGrantType extends keyof SimpleOauthGrantTypes,
+    TGrant extends SimpleOauthGrantTypes[TGrantType],
+  >(
+    grantType: TGrantType,
+    grant: TGrant,
+  ): URLSearchParams | DrupalkitSimpleOauthError => {
+    const fields = grantPayloadFields[grantType];
+    const invalidKeys = Object.keys(grant).filter((key) => !(key in fields));
+
+    if (invalidKeys.length) {
+      return new DrupalkitSimpleOauthError(
+        `Invalid ${String(grantType)} grant property "${invalidKeys[0]}".`,
+        400,
+        "invalid_request",
+        {
+          request: {
+            url: drupalkit.buildUrl(oauthTokenEndpoint),
+            baseUrl: drupalkitOptions.baseUrl,
+            method: "POST",
+            headers: {},
+          },
+        },
+        `Allowed properties: ${Object.keys(fields).join(", ")}`,
+      );
+    }
+
+    const body = new URLSearchParams();
+    const appendedFields = new Set<string>();
+    body.append("grant_type", String(grantType));
+
+    for (const [property, field] of Object.entries(fields)) {
+      if (appendedFields.has(field)) {
+        continue;
+      }
+
+      const value = grant[property as keyof typeof grant];
+      if (value === undefined || value === null) {
+        continue;
+      }
+
+      body.append(field, String(value));
+      appendedFields.add(field);
+    }
+
+    return body;
   };
 
   /**

--- a/packages/simple-oauth/src/types.ts
+++ b/packages/simple-oauth/src/types.ts
@@ -36,30 +36,51 @@ export interface SimpleOauthErrorResponse {
   hint?: string;
 }
 
-export interface SimpleOauthGrant {
+export type SimpleOauthGrant =
+  | SimpleOauthCamelCaseClient
+  | SimpleOauthSnakeCaseClient;
+
+export interface SimpleOauthCamelCaseClient {
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface SimpleOauthSnakeCaseClient {
   client_id: string;
   client_secret: string;
 }
 
-export interface SimpleOauthAuthCodeGrant extends SimpleOauthGrant {
+export type SimpleOauthAuthCodeGrant = SimpleOauthGrant & {
   code: string;
+  redirectUri?: string;
   redirect_uri?: string;
-}
+  codeVerifier?: string;
+  code_verifier?: string;
+};
 
-export interface SimpleOauthClientCredentialsGrant extends SimpleOauthGrant {
+export type SimpleOauthClientCredentialsGrant = SimpleOauthGrant & {
   scope?: string;
-}
+};
 
-export interface SimpleOauthRefreshTokenGrant extends SimpleOauthGrant {
-  refresh_token: string;
-  scope?: string;
-}
+export type SimpleOauthRefreshTokenGrant = SimpleOauthGrant &
+  (
+    | {
+        refreshToken: string;
+        refresh_token?: string;
+      }
+    | {
+        refresh_token: string;
+        refreshToken?: string;
+      }
+  ) & {
+    scope?: string;
+  };
 
-export interface SimpleOauthPasswordGrant extends SimpleOauthGrant {
+export type SimpleOauthPasswordGrant = SimpleOauthGrant & {
   username: string;
   password: string;
   scope?: string;
-}
+};
 
 export type SimpleOauthError =
   | "invalid_request"

--- a/packages/simple-oauth/tests/DrupalkitSimpleOauth.test.ts
+++ b/packages/simple-oauth/tests/DrupalkitSimpleOauth.test.ts
@@ -72,8 +72,8 @@ test.serial("Request token with client credentials grant", async (t) => {
   const result = await drupalkit.simpleOauth.requestToken(
     "client_credentials",
     {
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
     },
   );
 
@@ -102,8 +102,8 @@ test.serial("Request token with custom request options", async (t) => {
   await drupalkit.simpleOauth.requestToken(
     "client_credentials",
     {
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
     },
     {
       cache: "no-cache",
@@ -112,6 +112,72 @@ test.serial("Request token with custom request options", async (t) => {
       },
     },
   );
+});
+
+test.serial("Request token with PKCE code verifier", async (t) => {
+  t.plan(1);
+
+  const drupalkit = createDrupalkit();
+
+  server.use(
+    http.post("*/oauth/token", async ({ request }) => {
+      t.is(
+        await request.text(),
+        "grant_type=authorization_code&client_id=12345678901234567890123456789012&client_secret=F9w1cM0GQw7GjjQUaZcscWHtxnMOvn4d&code=abc&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&code_verifier=verifier",
+      );
+
+      return HttpResponse.json(TokenResponse);
+    }),
+  );
+
+  await drupalkit.simpleOauth.requestToken("authorization_code", {
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    code: "abc",
+    redirectUri: "https://example.com/callback",
+    codeVerifier: "verifier",
+  });
+});
+
+test.serial("Reject invalid token grant payload properties", async (t) => {
+  const drupalkit = createDrupalkit();
+
+  const result = await drupalkit.simpleOauth.requestToken(
+    "client_credentials",
+    {
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+      invalid: "value",
+    } as never,
+  );
+
+  const error = result.expectErr("Expected error");
+
+  t.assert(error instanceof DrupalkitSimpleOauthError);
+  t.is(error.statusCode, 400);
+  t.true(error.message.includes("invalid"));
+});
+
+test.serial("Allow legacy snake case token grant payloads", async (t) => {
+  t.plan(1);
+
+  const drupalkit = createDrupalkit();
+
+  server.use(
+    http.post("*/oauth/token", async ({ request }) => {
+      t.is(
+        await request.text(),
+        "grant_type=client_credentials&client_id=12345678901234567890123456789012&client_secret=F9w1cM0GQw7GjjQUaZcscWHtxnMOvn4d",
+      );
+
+      return HttpResponse.json(TokenResponse);
+    }),
+  );
+
+  await drupalkit.simpleOauth.requestToken("client_credentials", {
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+  });
 });
 
 test.serial("Request token authenticated", async (t) => {
@@ -138,8 +204,8 @@ test.serial("Request token authenticated", async (t) => {
   await drupalkit.simpleOauth.requestToken(
     "client_credentials",
     {
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
     },
     {
       cache: "no-cache",
@@ -164,8 +230,8 @@ test.serial("Request token with explicit endpoint", async (t) => {
   const result = await drupalkit.simpleOauth.requestToken(
     "client_credentials",
     {
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
     },
   );
 
@@ -184,8 +250,8 @@ test.serial("Handle request errors", async (t) => {
   const result = await drupalkit.simpleOauth.requestToken(
     "client_credentials",
     {
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
     },
   );
 
@@ -203,8 +269,8 @@ test.serial("Handle network errors", async (t) => {
   const result = await drupalkit.simpleOauth.requestToken(
     "client_credentials",
     {
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
     },
   );
 


### PR DESCRIPTION
## Summary
- add core default headers and dynamic auth providers
- sanitize detailed Drupal 5xx traces before exposing errors
- add JSON:API pagination params, optional relationship typing, and TS 5.5 declaration compatibility
- add camel-case OAuth grant payload mapping, validation, and PKCE codeVerifier support
- update README and add a changeset

## Verification
- pnpm check-all
- pnpm format:check
- pnpm syncpack
- pnpm --package=typescript@5.5.4 dlx tsc --project packages/jsonapi/tsconfig.json --noEmit false --emitDeclarationOnly --declaration --outDir /tmp/drupal-kit-jsonapi-ts55

Closes #20
Refs #25 (workflow release-note change was blocked by token scope)
Closes #42
Closes #46
Closes #62
Closes #72
Closes #73
Closes #84
Closes #85
Closes #91
Closes #93