### PR TITLE
Fix npm publish auth in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
   release:
     name: Release
     runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4


### PR DESCRIPTION
## 🐛 Bugfixes

- Restore NPM_TOKEN and NODE_AUTH_TOKEN in release workflow so changesets uses npm auth instead of OIDC fallback with GITHUB_TOKEN