### PR TITLE
chore(ci): migrate runners to on-prem

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   lint-and-test:
     name: Lint & Test
-    runs-on: ww-onprem-small
+    runs-on: ww-onprem-large
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   lint-and-test:
     name: Lint & Test
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ww-onprem-small
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    runs-on: ww-onprem-small
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Migrate CI runners to on-prem (`ww-onprem-small`).